### PR TITLE
Fix mobile avatar frame layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.pnpm-store/
 dist/
 .astro/
 .DS_Store

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -578,12 +578,13 @@ h1 {
 
   .page-shell {
     display: block;
-    max-width: 100vw;
+    width: 100%;
+    max-width: 100%;
     padding: 12px;
   }
 
   .profile-card {
-    width: calc(100vw - 24px);
+    width: 100%;
     max-width: 100%;
     min-height: calc(100svh - 24px);
     margin: 0 auto;
@@ -621,8 +622,9 @@ h1 {
     right: auto;
     bottom: auto;
     width: min(39vw, 146px);
+    aspect-ratio: 1;
     margin: 18px auto 0;
-    justify-self: center;
+    place-self: start center;
   }
 
   .social-links {


### PR DESCRIPTION
## Summary

- Keep the mobile avatar frame square so its decorative backing layers do not stretch or get clipped.
- Use container width for the mobile profile card instead of viewport width.
- Ignore the local pnpm store generated during dev-server setup.

## Verification

- `pnpm format`
- `pnpm build`
- Built-in browser at 320px and 390px: avatar frame, image, and decorative backing layers remain square with no horizontal overflow.

## Risks

- Low: CSS-only layout change scoped to the mobile breakpoint plus a gitignore hygiene entry.
