### PR TITLE
Redesign profile site with interactive CRT portrait

### DIFF
--- a/src/data/profile.ts
+++ b/src/data/profile.ts
@@ -2,29 +2,54 @@ export const profile = {
   name: "ViPro",
   handle: "VdustR",
   site: "https://vdustr.dev",
-  avatar: "https://github.com/VdustR.png",
+  avatar: "https://avatars.githubusercontent.com/u/29639463?v=4",
+  headline: "Make complex work feel obvious.",
   intro:
-    "AI builder focused on calm interfaces, practical tooling, and automation for complex work.",
-  links: [
+    "I’m a developer turning tangled workflows into calm interfaces, practical tools, and automation people can trust.",
+  disciplines: ["Interfaces", "Tooling", "Automation"],
+  statement: "I design the layer between people and complexity.",
+  focus: [
     {
-      label: "Website",
-      href: "https://vdustr.dev",
-      detail: "vdustr.dev",
+      name: "Interfaces",
+      description: "Operational surfaces that stay calm when the work gets complicated.",
+      signal: "Clarity",
     },
+    {
+      name: "Tooling",
+      description: "Small, sharp systems shaped around the way people actually work.",
+      signal: "Leverage",
+    },
+    {
+      name: "Automation",
+      description: "Machine speed with human judgment left firmly in the loop.",
+      signal: "Control",
+    },
+  ],
+  links: [
     {
       label: "GitHub",
       href: "https://github.com/VdustR",
       detail: "@VdustR",
     },
     {
+      label: "X",
+      href: "https://x.com/vp_tw",
+      detail: "@vp_tw",
+    },
+    {
+      label: "Blog",
+      href: "https://vdustr.github.io/blog",
+      detail: "vdustr.github.io/blog",
+    },
+    {
+      label: "Medium",
+      href: "https://medium.com/@vdustr",
+      detail: "@vdustr",
+    },
+    {
       label: "LinkedIn",
       href: "https://www.linkedin.com/in/vdustr/",
       detail: "/in/vdustr",
-    },
-    {
-      label: "X",
-      href: "https://twitter.com/vp_tw",
-      detail: "@vp_tw",
     },
   ],
 } as const;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -155,7 +155,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
               <div class="focus-item">
                 <dt>{item.name}</dt>
                 <dd>{item.description}</dd>
-                <span>{item.signal}</span>
+                <dd class="focus-signal">{item.signal}</dd>
               </div>
             ))
           }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -459,7 +459,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
                     uvScale.x = 1;
                     uvScale.y = visibleHeight;
                     uvOffset.x = 0;
-                    uvOffset.y = 0.56 - 0.5 * visibleHeight;
+                    uvOffset.y = 0.6 * (1 - visibleHeight);
                   } else {
                     const visibleWidth = aspect / imageAspect;
                     uvScale.x = visibleWidth;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -421,7 +421,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
               let interaction = 0;
               let targetInteraction = 0;
               let pulse = 0;
-              let previousMilliseconds = 0;
+              let previousMilliseconds: number | null = null;
 
               gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
               gl.bufferData(
@@ -447,9 +447,10 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
 
               const draw = (milliseconds: number) => {
                 if (!textureReady) return;
-                const deltaSeconds = previousMilliseconds
-                  ? Math.min((milliseconds - previousMilliseconds) / 1000, 0.05)
-                  : 0;
+                const deltaSeconds =
+                  previousMilliseconds !== null
+                    ? Math.min((milliseconds - previousMilliseconds) / 1000, 0.05)
+                    : 0;
                 previousMilliseconds = milliseconds;
                 pointer.x += (targetPointer.x - pointer.x) * 0.055;
                 pointer.y += (targetPointer.y - pointer.y) * 0.055;
@@ -551,14 +552,14 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
               visibilityObserver.observe(stage);
               new ResizeObserver(() => {
                 resize();
-                if (!isVisible || reducedMotion.matches) draw(previousMilliseconds);
+                if (!isVisible || reducedMotion.matches) draw(previousMilliseconds ?? 0);
               }).observe(stage);
               reducedMotion.addEventListener("change", () => {
                 cancelAnimationFrame(animationFrame);
                 interaction = 0;
                 targetInteraction = 0;
                 pulse = 0;
-                previousMilliseconds = 0;
+                previousMilliseconds = null;
                 draw(0);
               });
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -447,7 +447,6 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
 
               const draw = (milliseconds: number) => {
                 if (!textureReady) return;
-                resize();
                 const deltaSeconds = previousMilliseconds
                   ? Math.min((milliseconds - previousMilliseconds) / 1000, 0.05)
                   : 0;
@@ -492,6 +491,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
                   gl.uniform1i(imageUniform, 0);
                   gl.uniform2f(imageSize, portrait.naturalWidth, portrait.naturalHeight);
 
+                  resize();
                   textureReady = true;
                   stage.dataset.portraitState = "ready";
                   draw(0);
@@ -501,10 +501,11 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
               };
 
               const updatePointer = (event: PointerEvent) => {
-                const bounds = canvas.getBoundingClientRect();
-                if (bounds.width === 0 || bounds.height === 0) return;
-                targetPointer.x = ((event.clientX - bounds.left) / bounds.width) * 2 - 1;
-                targetPointer.y = 1 - ((event.clientY - bounds.top) / bounds.height) * 2;
+                const width = canvas.clientWidth;
+                const height = canvas.clientHeight;
+                if (width === 0 || height === 0) return;
+                targetPointer.x = (event.offsetX / width) * 2 - 1;
+                targetPointer.y = 1 - (event.offsetY / height) * 2;
               };
 
               canvas.addEventListener(
@@ -574,6 +575,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
         let pointerFrame = 0;
         let pointerX = 72;
         let pointerY = 42;
+        let cachedBounds: DOMRect | null = null;
 
         const renderHeroPointer = () => {
           hero.style.setProperty("--pointer-x", `${pointerX}%`);
@@ -583,10 +585,23 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
           pointerFrame = 0;
         };
 
+        const clearCachedBounds = () => {
+          cachedBounds = null;
+        };
+
+        hero.addEventListener(
+          "pointerenter",
+          () => {
+            cachedBounds = hero.getBoundingClientRect();
+          },
+          { passive: true },
+        );
+
         hero.addEventListener(
           "pointermove",
           (event) => {
-            const bounds = hero.getBoundingClientRect();
+            const bounds = cachedBounds ?? hero.getBoundingClientRect();
+            cachedBounds = bounds;
             if (bounds.width === 0 || bounds.height === 0) return;
             pointerX = ((event.clientX - bounds.left) / bounds.width) * 100;
             pointerY = ((event.clientY - bounds.top) / bounds.height) * 100;
@@ -596,10 +611,14 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
         );
 
         hero.addEventListener("pointerleave", () => {
+          clearCachedBounds();
           pointerX = 72;
           pointerY = 42;
           if (!pointerFrame) pointerFrame = requestAnimationFrame(renderHeroPointer);
         });
+
+        window.addEventListener("scroll", clearCachedBounds, { passive: true });
+        new ResizeObserver(clearCachedBounds).observe(hero);
       }
     </script>
   </body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,9 @@ import "../styles/global.css";
 const pageTitle = `${profile.name} (@${profile.handle})`;
 const pageDescription = profile.intro;
 const ogImage = new URL("/og.png", profile.site).toString();
+const githubLink = profile.links.find((link) => link.label === "GitHub") ?? profile.links[0];
+const xLink = profile.links.find((link) => link.label === "X") ?? profile.links[0];
+const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
 ---
 
 <!doctype html>
@@ -12,8 +15,8 @@ const ogImage = new URL("/og.png", profile.site).toString();
   <head>
     <meta charset="UTF-8" />
     <meta name="description" content={pageDescription} />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#f4f1e8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#f6f5f7" />
     <meta property="og:title" content={pageTitle} />
     <meta property="og:description" content={pageDescription} />
     <meta property="og:type" content="website" />
@@ -28,6 +31,14 @@ const ogImage = new URL("/og.png", profile.site).toString();
     <meta name="twitter:description" content={pageDescription} />
     <meta name="twitter:image" content={ogImage} />
     <link rel="canonical" href={profile.site} />
+    <link rel="preconnect" href="https://avatars.githubusercontent.com" />
+    <link
+      rel="preload"
+      href={profile.avatar}
+      as="image"
+      crossorigin="anonymous"
+      fetchpriority="high"
+    />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" href="/favicon.png" type="image/png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
@@ -47,60 +58,534 @@ const ogImage = new URL("/og.png", profile.site).toString();
       })}
     />
   </head>
-  <body>
-    <div class="ambient-field" aria-hidden="true">
-      <span class="ambient-node ambient-node-a"></span>
-      <span class="ambient-node ambient-node-b"></span>
-      <span class="ambient-node ambient-node-c"></span>
-      <span class="ambient-plane ambient-plane-a"></span>
-      <span class="ambient-plane ambient-plane-b"></span>
-    </div>
+  <body id="top">
+    <header class="site-header">
+      <a class="wordmark" href="/" aria-label={`${profile.name} home`}>
+        <span>{profile.name}</span>
+        <small>@{profile.handle}</small>
+      </a>
 
-    <main class="page-shell" aria-labelledby="identity-title">
-      <article class="profile-card" aria-label={`${profile.name} profile`}>
-        <div class="identity">
-          <p class="handle">@{profile.handle}</p>
-          <h1 id="identity-title">{profile.name}</h1>
-          <p class="intro">{profile.intro}</p>
+      <nav class="header-nav" aria-label="Primary navigation">
+        <a href="#focus">What I do</a>
+        <a href="#contact">Contact</a>
+      </nav>
+
+      <p class="availability">
+        <span class="availability-dot" aria-hidden="true"></span>
+        <span class="availability-long">Available for good problems</span>
+        <span class="availability-short">Available</span>
+      </p>
+    </header>
+
+    <main>
+      <section class="hero" aria-labelledby="hero-title">
+        <div class="hero-light-field" aria-hidden="true"></div>
+
+        <div class="hero-copy">
+          <p class="hero-role">Developer, interface maker, systems thinker.</p>
+          <h1 id="hero-title" aria-label={profile.headline}>
+            {
+              headlineLines.map((line) => (
+                <span class="headline-mask" aria-hidden="true">
+                  <span class="headline-line">
+                    {line.map((word) => (
+                      <span class="headline-word">{word}</span>
+                    ))}
+                  </span>
+                </span>
+              ))
+            }
+          </h1>
+          <p class="hero-description">{profile.intro}</p>
+
+          <div class="hero-actions">
+            <a
+              class="action action-primary"
+              href={githubLink.href}
+              target="_blank"
+              rel="me noopener noreferrer"
+            >
+              Explore my work <span aria-hidden="true">↗</span>
+            </a>
+            <a
+              class="action action-secondary"
+              href={xLink.href}
+              target="_blank"
+              rel="me noopener noreferrer"
+            >
+              Find me on X
+            </a>
+          </div>
         </div>
 
-        <div class="profile-visual">
-          <div class="signal-field" aria-hidden="true">
-            <span class="plane plane-a"></span>
-            <span class="plane plane-b"></span>
-            <span class="plane plane-c"></span>
-            <span class="node node-a"></span>
-            <span class="node node-b"></span>
-            <span class="node node-c"></span>
-          </div>
-
-          <figure class="avatar-frame">
-            <img
-              src={profile.avatar}
-              width="256"
-              height="256"
-              alt={`${profile.handle} avatar`}
-              decoding="async"
-              fetchpriority="high"
-            />
+        <div class="portrait-stage-shell">
+          <figure class="portrait-stage" data-portrait-state="loading">
+            <div class="portrait-media">
+              <img
+                src={profile.avatar}
+                width="800"
+                height="800"
+                alt={`${profile.name}, known online as ${profile.handle}`}
+                crossorigin="anonymous"
+                decoding="async"
+                fetchpriority="high"
+              />
+              <canvas class="portrait-canvas" aria-hidden="true"></canvas>
+              <div class="portrait-glare" aria-hidden="true"></div>
+            </div>
+            <figcaption>
+              <strong>{profile.name}</strong>
+              <span>Human judgment, amplified.</span>
+            </figcaption>
           </figure>
         </div>
 
-        <nav class="social-links" aria-label="Social links">
+        <p class="hero-margin-note" aria-hidden="true">Interfaces / Tools / Automation</p>
+      </section>
+
+      <section class="focus-section" id="focus" aria-labelledby="focus-title">
+        <div class="focus-statement">
+          <p>What I make</p>
+          <h2 id="focus-title">{profile.statement}</h2>
+        </div>
+
+        <dl class="focus-list">
           {
-            profile.links.map((link) => (
-              <a href={link.href} rel="me noopener noreferrer" target="_blank">
-                <span>{link.label}</span>
-                <small>{link.detail}</small>
-              </a>
+            profile.focus.map((item) => (
+              <div class="focus-item">
+                <dt>{item.name}</dt>
+                <dd>{item.description}</dd>
+                <span>{item.signal}</span>
+              </div>
             ))
           }
-        </nav>
+        </dl>
+      </section>
 
-        <footer class="profile-footer">
-          <p>Copyright 2026 {profile.handle}.</p>
-        </footer>
-      </article>
+      <section class="contact-section" id="contact" aria-labelledby="contact-title">
+        <p>Have a difficult idea?</p>
+        <h2 id="contact-title">Bring me the tangled part.</h2>
+        <a href={xLink.href} target="_blank" rel="me noopener noreferrer">
+          Continue on X <span aria-hidden="true">↗</span>
+        </a>
+      </section>
     </main>
+
+    <footer class="site-footer">
+      <a class="footer-identity" href="/">{profile.name} <span>@{profile.handle}</span></a>
+      <nav aria-label="Social links">
+        {
+          profile.links.map((link) => (
+            <a href={link.href} rel="me noopener noreferrer" target="_blank">
+              {link.label}
+            </a>
+          ))
+        }
+      </nav>
+      <p>© 2026</p>
+    </footer>
+
+    <script>
+      const canvas = document.querySelector(".portrait-canvas");
+      const stage = document.querySelector(".portrait-stage");
+      const portrait = document.querySelector(".portrait-media img");
+
+      if (
+        canvas instanceof HTMLCanvasElement &&
+        stage instanceof HTMLElement &&
+        portrait instanceof HTMLImageElement
+      ) {
+        const gl = canvas.getContext("webgl2", {
+          alpha: false,
+          antialias: false,
+          depth: false,
+          powerPreference: "low-power",
+        });
+
+        const setFallback = () => {
+          stage.dataset.portraitState = "fallback";
+        };
+
+        if (!gl) {
+          setFallback();
+        } else {
+          const vertexSource = `#version 300 es
+            in vec2 aPosition;
+            out vec2 vUv;
+
+            void main() {
+              vUv = aPosition * 0.5 + 0.5;
+              gl_Position = vec4(aPosition, 0.0, 1.0);
+            }
+          `;
+
+          const fragmentSource = `#version 300 es
+            precision highp float;
+
+            uniform sampler2D uImage;
+            uniform vec2 uResolution;
+            uniform vec2 uImageSize;
+            uniform vec2 uPointer;
+            uniform float uInteraction;
+            uniform float uPulse;
+            uniform float uTime;
+
+            in vec2 vUv;
+            out vec4 outColor;
+
+            float hash(vec2 p) {
+              p = fract(p * vec2(123.34, 345.45));
+              p += dot(p, p + 34.345);
+              return fract(p.x * p.y);
+            }
+
+            vec2 coverUv(vec2 uv) {
+              float screenAspect = uResolution.x / max(uResolution.y, 1.0);
+              float imageAspect = uImageSize.x / max(uImageSize.y, 1.0);
+
+              if (screenAspect > imageAspect) {
+                float visibleHeight = imageAspect / screenAspect;
+                uv.y = 0.56 + (uv.y - 0.5) * visibleHeight;
+              } else {
+                float visibleWidth = screenAspect / imageAspect;
+                uv.x = 0.5 + (uv.x - 0.5) * visibleWidth;
+              }
+
+              return clamp(uv, 0.001, 0.999);
+            }
+
+            vec3 imageAt(vec2 uv) {
+              return texture(uImage, coverUv(uv)).rgb;
+            }
+
+            void main() {
+              float time = uTime;
+              vec2 centered = vUv * 2.0 - 1.0;
+              float radiusSquared = dot(centered, centered);
+              centered *= 1.0 + radiusSquared * 0.052;
+              vec2 curvedUv = centered * 0.5 + 0.5;
+
+              float edge = min(min(curvedUv.x, 1.0 - curvedUv.x), min(curvedUv.y, 1.0 - curvedUv.y));
+              float glassEdge = smoothstep(-0.018, 0.035, edge);
+
+              vec2 pointerUv = uPointer * 0.5 + 0.5;
+              vec2 pointerDelta = (vUv - pointerUv) * vec2(uResolution.x / uResolution.y, 1.0);
+              float pointerDistance = length(pointerDelta);
+              float interactionField = exp(-pointerDistance * 4.6) * uInteraction;
+              float pulseField = exp(-pointerDistance * 3.2) * uPulse;
+              float disturbance = clamp(interactionField + pulseField, 0.0, 1.0);
+
+              float interferenceLine = floor(curvedUv.y * uResolution.y * 0.16);
+              float interferenceNoise = hash(vec2(interferenceLine, floor(time * 27.0))) - 0.5;
+              float interferenceWave = sin((curvedUv.y - pointerUv.y) * 190.0 + time * 36.0);
+              curvedUv.x += interferenceNoise * 0.032 * disturbance;
+              curvedUv.x += interferenceWave * 0.0045 * disturbance;
+
+              float line = floor(curvedUv.y * uResolution.y * 0.38);
+              float tearGate = step(0.988, hash(vec2(line, floor(time * 5.0))));
+              float tear = (hash(vec2(line, floor(time * 23.0))) - 0.5) * 0.022 * tearGate;
+              curvedUv.x += tear;
+
+              vec2 chroma = (curvedUv - 0.5) * (0.008 + disturbance * 0.022);
+              chroma.x += sin(time * 1.7) * 0.0008;
+              chroma.x += interferenceWave * disturbance * 0.0028;
+              vec3 base;
+              base.r = imageAt(curvedUv + chroma).r;
+              base.g = imageAt(curvedUv).g;
+              base.b = imageAt(curvedUv - chroma).b;
+
+              vec2 pixel = 2.8 / uResolution;
+              vec3 bloom = imageAt(curvedUv + vec2(pixel.x, 0.0));
+              bloom += imageAt(curvedUv - vec2(pixel.x, 0.0));
+              bloom += imageAt(curvedUv + vec2(0.0, pixel.y));
+              bloom += imageAt(curvedUv - vec2(0.0, pixel.y));
+              bloom += imageAt(curvedUv + pixel);
+              bloom += imageAt(curvedUv - pixel);
+              bloom *= 0.1667;
+
+              float bloomLuma = dot(bloom, vec3(0.2126, 0.7152, 0.0722));
+              vec3 halation = max(bloom - 0.42, 0.0) * vec3(0.78, 0.22, 0.12) * 0.62;
+              vec3 color = mix(base, bloom, 0.12) + halation;
+
+              vec2 haloPixel = 11.0 / uResolution;
+              vec3 wideBloom = imageAt(curvedUv + vec2(haloPixel.x, 0.0));
+              wideBloom += imageAt(curvedUv - vec2(haloPixel.x, 0.0));
+              wideBloom += imageAt(curvedUv + vec2(0.0, haloPixel.y));
+              wideBloom += imageAt(curvedUv - vec2(0.0, haloPixel.y));
+              wideBloom *= 0.25;
+              vec3 redGlow = max(wideBloom - 0.3, 0.0) * vec3(0.72, 0.12, 0.055) * 0.72;
+              color += redGlow;
+
+              float scanline = 0.76 + 0.24 * (0.5 + 0.5 * sin(gl_FragCoord.y * 3.14159265));
+              float beamTexture = 0.96 + 0.04 * sin(gl_FragCoord.y * 1.047 + time * 1.8);
+              color *= scanline * beamTexture;
+
+              float triadIndex = mod(floor(gl_FragCoord.x), 3.0);
+              vec3 phosphor = triadIndex < 1.0
+                ? vec3(1.0, 0.72, 0.72)
+                : triadIndex < 2.0
+                  ? vec3(0.74, 1.0, 0.72)
+                  : vec3(0.72, 0.78, 1.0);
+              color *= mix(vec3(1.0), phosphor, 0.24);
+
+              float grain = hash(gl_FragCoord.xy + vec2(time * 41.0, time * 17.0)) - 0.5;
+              float lineNoise = hash(vec2(line, floor(time * 29.0))) - 0.5;
+              float signalDropout = step(
+                0.82,
+                hash(vec2(floor(curvedUv.y * 110.0), floor(time * 31.0)))
+              );
+              color *= 1.0 - signalDropout * disturbance * 0.28;
+              color += grain * (0.075 + disturbance * 0.18);
+              color += lineNoise * (0.024 + disturbance * 0.08);
+
+              float pointerGlow = exp(-length(pointerDelta) * 3.2);
+              color += vec3(1.0, 0.34, 0.2) * pointerGlow * 0.17;
+
+              float pulseRadius = (1.0 - uPulse) * 0.42;
+              float pulseRing = exp(-abs(pointerDistance - pulseRadius) * 36.0) * uPulse;
+              color += vec3(1.0, 0.24, 0.12) * pulseRing * 0.2;
+
+              vec2 reflectionDelta = (vUv - vec2(0.7, 0.16)) * vec2(uResolution.x / uResolution.y, 1.0);
+              float glassReflection = exp(-length(reflectionDelta) * 5.2);
+              color += vec3(1.0, 0.72, 0.58) * glassReflection * 0.085;
+
+              float beamPosition = fract(time * 0.035 + 0.12);
+              float movingBeam = exp(-abs(vUv.y - beamPosition) * 26.0);
+              color += vec3(1.0, 0.48, 0.28) * movingBeam * 0.07;
+
+              vec2 vignetteUv = curvedUv * (1.0 - curvedUv);
+              float vignette = pow(clamp(vignetteUv.x * vignetteUv.y * 18.0, 0.0, 1.0), 0.22);
+              float flicker = 0.982 + sin(time * 47.0) * 0.012 + sin(time * 8.3) * 0.006;
+              color *= vignette * glassEdge * flicker * 1.06;
+              color += halation * pointerGlow * 0.42;
+              color = pow(max(color, 0.0), vec3(0.92));
+
+              outColor = vec4(color, 1.0);
+            }
+          `;
+
+          const compileShader = (type: number, source: string) => {
+            const shader = gl.createShader(type);
+            if (!shader) return null;
+            gl.shaderSource(shader, source);
+            gl.compileShader(shader);
+
+            if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+              gl.deleteShader(shader);
+              return null;
+            }
+
+            return shader;
+          };
+
+          const vertexShader = compileShader(gl.VERTEX_SHADER, vertexSource);
+          const fragmentShader = compileShader(gl.FRAGMENT_SHADER, fragmentSource);
+          const program = gl.createProgram();
+
+          if (!vertexShader || !fragmentShader || !program) {
+            setFallback();
+          } else {
+            gl.attachShader(program, vertexShader);
+            gl.attachShader(program, fragmentShader);
+            gl.linkProgram(program);
+
+            if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+              setFallback();
+            } else {
+              const buffer = gl.createBuffer();
+              const texture = gl.createTexture();
+              const position = gl.getAttribLocation(program, "aPosition");
+              const imageUniform = gl.getUniformLocation(program, "uImage");
+              const resolution = gl.getUniformLocation(program, "uResolution");
+              const imageSize = gl.getUniformLocation(program, "uImageSize");
+              const pointerUniform = gl.getUniformLocation(program, "uPointer");
+              const interactionUniform = gl.getUniformLocation(program, "uInteraction");
+              const pulseUniform = gl.getUniformLocation(program, "uPulse");
+              const timeUniform = gl.getUniformLocation(program, "uTime");
+              const pointer = { x: 0.22, y: -0.18 };
+              const targetPointer = { ...pointer };
+              const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+              let animationFrame = 0;
+              let isVisible = true;
+              let textureReady = false;
+              let interaction = 0;
+              let targetInteraction = 0;
+              let pulse = 0;
+              let previousMilliseconds = 0;
+
+              gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+              gl.bufferData(
+                gl.ARRAY_BUFFER,
+                new Float32Array([-1, -1, 3, -1, -1, 3]),
+                gl.STATIC_DRAW,
+              );
+              gl.useProgram(program);
+              gl.enableVertexAttribArray(position);
+              gl.vertexAttribPointer(position, 2, gl.FLOAT, false, 0, 0);
+
+              const resize = () => {
+                const dpr = Math.min(window.devicePixelRatio, 1.6);
+                const width = Math.max(1, Math.round(canvas.clientWidth * dpr));
+                const height = Math.max(1, Math.round(canvas.clientHeight * dpr));
+
+                if (canvas.width !== width || canvas.height !== height) {
+                  canvas.width = width;
+                  canvas.height = height;
+                  gl.viewport(0, 0, width, height);
+                }
+              };
+
+              const draw = (milliseconds: number) => {
+                if (!textureReady) return;
+                resize();
+                const deltaSeconds = previousMilliseconds
+                  ? Math.min((milliseconds - previousMilliseconds) / 1000, 0.05)
+                  : 0;
+                previousMilliseconds = milliseconds;
+                pointer.x += (targetPointer.x - pointer.x) * 0.055;
+                pointer.y += (targetPointer.y - pointer.y) * 0.055;
+                interaction +=
+                  (targetInteraction - interaction) * (1 - Math.exp(-deltaSeconds * 11));
+                pulse = Math.max(0, pulse - deltaSeconds * 1.8);
+
+                gl.uniform2f(resolution, canvas.width, canvas.height);
+                gl.uniform2f(pointerUniform, pointer.x, pointer.y);
+                gl.uniform1f(interactionUniform, interaction);
+                gl.uniform1f(pulseUniform, pulse);
+                gl.uniform1f(timeUniform, milliseconds / 1000);
+                gl.drawArrays(gl.TRIANGLES, 0, 3);
+
+                if (isVisible && !reducedMotion.matches) {
+                  animationFrame = requestAnimationFrame(draw);
+                }
+              };
+
+              const uploadPortrait = async () => {
+                try {
+                  if (!portrait.complete || portrait.naturalWidth === 0) {
+                    await portrait.decode();
+                  }
+
+                  if (!texture) {
+                    setFallback();
+                    return;
+                  }
+
+                  gl.activeTexture(gl.TEXTURE0);
+                  gl.bindTexture(gl.TEXTURE_2D, texture);
+                  gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+                  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+                  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+                  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+                  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+                  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, portrait);
+                  gl.uniform1i(imageUniform, 0);
+                  gl.uniform2f(imageSize, portrait.naturalWidth, portrait.naturalHeight);
+
+                  textureReady = true;
+                  stage.dataset.portraitState = "ready";
+                  draw(0);
+                } catch {
+                  setFallback();
+                }
+              };
+
+              const updatePointer = (event: PointerEvent) => {
+                const bounds = canvas.getBoundingClientRect();
+                targetPointer.x = ((event.clientX - bounds.left) / bounds.width) * 2 - 1;
+                targetPointer.y = 1 - ((event.clientY - bounds.top) / bounds.height) * 2;
+              };
+
+              canvas.addEventListener(
+                "pointermove",
+                (event) => {
+                  updatePointer(event);
+                  if (event.pointerType === "mouse") targetInteraction = 1;
+                },
+                { passive: true },
+              );
+              canvas.addEventListener(
+                "pointerdown",
+                (event) => {
+                  if (reducedMotion.matches) return;
+                  updatePointer(event);
+                  pulse = 1;
+                  if (event.pointerType === "mouse") targetInteraction = 1;
+                },
+                { passive: true },
+              );
+              canvas.addEventListener("pointerleave", (event) => {
+                if (event.pointerType === "mouse") targetInteraction = 0;
+                targetPointer.x = 0.22;
+                targetPointer.y = -0.18;
+              });
+              canvas.addEventListener("pointercancel", () => {
+                targetInteraction = 0;
+              });
+
+              canvas.addEventListener("webglcontextlost", (event) => {
+                event.preventDefault();
+                textureReady = false;
+                cancelAnimationFrame(animationFrame);
+                setFallback();
+              });
+
+              const visibilityObserver = new IntersectionObserver(([entry]) => {
+                isVisible = entry?.isIntersecting ?? false;
+                cancelAnimationFrame(animationFrame);
+                if (isVisible && textureReady) animationFrame = requestAnimationFrame(draw);
+              });
+
+              visibilityObserver.observe(stage);
+              new ResizeObserver(resize).observe(stage);
+              reducedMotion.addEventListener("change", () => {
+                cancelAnimationFrame(animationFrame);
+                interaction = 0;
+                targetInteraction = 0;
+                pulse = 0;
+                previousMilliseconds = 0;
+                draw(0);
+              });
+
+              void uploadPortrait();
+            }
+          }
+        }
+      }
+
+      const hero = document.querySelector(".hero");
+      const reducedMotionPreference = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+      if (hero instanceof HTMLElement && !reducedMotionPreference.matches) {
+        let pointerFrame = 0;
+        let pointerX = 72;
+        let pointerY = 42;
+
+        const renderHeroPointer = () => {
+          hero.style.setProperty("--pointer-x", `${pointerX}%`);
+          hero.style.setProperty("--pointer-y", `${pointerY}%`);
+          hero.style.setProperty("--parallax-x", `${(pointerX - 50) * 0.09}px`);
+          hero.style.setProperty("--parallax-y", `${(pointerY - 50) * 0.07}px`);
+          pointerFrame = 0;
+        };
+
+        hero.addEventListener(
+          "pointermove",
+          (event) => {
+            const bounds = hero.getBoundingClientRect();
+            pointerX = ((event.clientX - bounds.left) / bounds.width) * 100;
+            pointerY = ((event.clientY - bounds.top) / bounds.height) * 100;
+            if (!pointerFrame) pointerFrame = requestAnimationFrame(renderHeroPointer);
+          },
+          { passive: true },
+        );
+
+        hero.addEventListener("pointerleave", () => {
+          pointerX = 72;
+          pointerY = 42;
+          if (!pointerFrame) pointerFrame = requestAnimationFrame(renderHeroPointer);
+        });
+      }
+    </script>
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -452,7 +452,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
                 gl.uniform2f(pointerUniform, pointer.x, pointer.y);
                 gl.uniform1f(interactionUniform, interaction);
                 gl.uniform1f(pulseUniform, pulse);
-                gl.uniform1f(timeUniform, milliseconds / 1000);
+                gl.uniform1f(timeUniform, (milliseconds / 1000) % 3600);
                 gl.drawArrays(gl.TRIANGLES, 0, 3);
 
                 if (isVisible && !reducedMotion.matches) {
@@ -537,7 +537,10 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
               });
 
               visibilityObserver.observe(stage);
-              new ResizeObserver(resize).observe(stage);
+              new ResizeObserver(() => {
+                resize();
+                if (!isVisible || reducedMotion.matches) draw(previousMilliseconds);
+              }).observe(stage);
               reducedMotion.addEventListener("change", () => {
                 cancelAnimationFrame(animationFrame);
                 interaction = 0;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -224,7 +224,9 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
 
             uniform sampler2D uImage;
             uniform vec2 uResolution;
-            uniform vec2 uImageSize;
+            uniform vec2 uUvScale;
+            uniform vec2 uUvOffset;
+            uniform vec2 uAspectScale;
             uniform vec2 uPointer;
             uniform float uInteraction;
             uniform float uPulse;
@@ -233,9 +235,6 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
             in vec2 vUv;
             out vec4 outColor;
 
-            vec2 uvScale;
-            vec2 uvOffset;
-
             float hash(vec2 p) {
               p = fract(p * vec2(123.34, 345.45));
               p += dot(p, p + 34.345);
@@ -243,7 +242,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
             }
 
             vec2 coverUv(vec2 uv) {
-              return clamp(uv * uvScale + uvOffset, 0.001, 0.999);
+              return clamp(uv * uUvScale + uUvOffset, 0.001, 0.999);
             }
 
             vec3 imageAt(vec2 uv) {
@@ -251,20 +250,6 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
             }
 
             void main() {
-              float aspect = uResolution.x / max(uResolution.y, 1.0);
-              float imageAspect = uImageSize.x / max(uImageSize.y, 1.0);
-
-              if (aspect > imageAspect) {
-                float visibleHeight = imageAspect / aspect;
-                uvScale = vec2(1.0, visibleHeight);
-                uvOffset = vec2(0.0, 0.56 - 0.5 * visibleHeight);
-              } else {
-                float visibleWidth = aspect / imageAspect;
-                uvScale = vec2(visibleWidth, 1.0);
-                uvOffset = vec2(0.5 - 0.5 * visibleWidth, 0.0);
-              }
-
-              vec2 aspectScale = vec2(aspect, 1.0);
               float time = uTime;
               vec2 centered = vUv * 2.0 - 1.0;
               float radiusSquared = dot(centered, centered);
@@ -275,7 +260,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
               float glassEdge = smoothstep(-0.018, 0.035, edge);
 
               vec2 pointerUv = uPointer * 0.5 + 0.5;
-              vec2 pointerDelta = (vUv - pointerUv) * aspectScale;
+              vec2 pointerDelta = (vUv - pointerUv) * uAspectScale;
               float pointerDistance = length(pointerDelta);
               float interactionField = exp(-pointerDistance * 4.6) * uInteraction;
               float pulseField = exp(-pointerDistance * 3.2) * uPulse;
@@ -351,7 +336,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
               float pulseRing = exp(-abs(pointerDistance - pulseRadius) * 36.0) * uPulse;
               color += vec3(1.0, 0.24, 0.12) * pulseRing * 0.2;
 
-              vec2 reflectionDelta = (vUv - vec2(0.7, 0.16)) * aspectScale;
+              vec2 reflectionDelta = (vUv - vec2(0.7, 0.16)) * uAspectScale;
               float glassReflection = exp(-length(reflectionDelta) * 5.2);
               color += vec3(1.0, 0.72, 0.58) * glassReflection * 0.085;
 
@@ -412,171 +397,199 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
             } else {
               const buffer = gl.createBuffer();
               const texture = gl.createTexture();
-              const position = gl.getAttribLocation(program, "aPosition");
-              const imageUniform = gl.getUniformLocation(program, "uImage");
-              const resolution = gl.getUniformLocation(program, "uResolution");
-              const imageSize = gl.getUniformLocation(program, "uImageSize");
-              const pointerUniform = gl.getUniformLocation(program, "uPointer");
-              const interactionUniform = gl.getUniformLocation(program, "uInteraction");
-              const pulseUniform = gl.getUniformLocation(program, "uPulse");
-              const timeUniform = gl.getUniformLocation(program, "uTime");
-              const pointer = { x: 0.22, y: -0.18 };
-              const targetPointer = { ...pointer };
-              const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
-              let animationFrame = 0;
-              let isVisible = true;
-              let textureReady = false;
-              let interaction = 0;
-              let targetInteraction = 0;
-              let pulse = 0;
-              let previousMilliseconds: number | null = null;
 
-              gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-              gl.bufferData(
-                gl.ARRAY_BUFFER,
-                new Float32Array([-1, -1, 3, -1, -1, 3]),
-                gl.STATIC_DRAW,
-              );
-              gl.useProgram(program);
-              gl.enableVertexAttribArray(position);
-              gl.vertexAttribPointer(position, 2, gl.FLOAT, false, 0, 0);
-
-              const resize = () => {
-                const dpr = Math.min(window.devicePixelRatio, 1.6);
-                const width = Math.max(1, Math.round(canvas.clientWidth * dpr));
-                const height = Math.max(1, Math.round(canvas.clientHeight * dpr));
-
-                if (canvas.width !== width || canvas.height !== height) {
-                  canvas.width = width;
-                  canvas.height = height;
-                  gl.viewport(0, 0, width, height);
-                }
-              };
-
-              const draw = (milliseconds: number) => {
-                if (!textureReady) return;
-                const deltaSeconds =
-                  previousMilliseconds !== null
-                    ? Math.min((milliseconds - previousMilliseconds) / 1000, 0.05)
-                    : 0;
-                previousMilliseconds = milliseconds;
-                pointer.x += (targetPointer.x - pointer.x) * 0.055;
-                pointer.y += (targetPointer.y - pointer.y) * 0.055;
-                interaction +=
-                  (targetInteraction - interaction) * (1 - Math.exp(-deltaSeconds * 11));
-                pulse = Math.max(0, pulse - deltaSeconds * 1.8);
-
-                gl.uniform2f(resolution, canvas.width, canvas.height);
-                gl.uniform2f(pointerUniform, pointer.x, pointer.y);
-                gl.uniform1f(interactionUniform, interaction);
-                gl.uniform1f(pulseUniform, pulse);
-                gl.uniform1f(timeUniform, (milliseconds / 1000) % 3600);
-                gl.drawArrays(gl.TRIANGLES, 0, 3);
-
-                if (isVisible && !reducedMotion.matches) {
-                  animationFrame = requestAnimationFrame(draw);
-                }
-              };
-
-              const uploadPortrait = async () => {
-                try {
-                  if (!portrait.complete || portrait.naturalWidth === 0) {
-                    await portrait.decode();
-                  }
-
-                  if (!texture) {
-                    setFallback();
-                    return;
-                  }
-
-                  gl.activeTexture(gl.TEXTURE0);
-                  gl.bindTexture(gl.TEXTURE_2D, texture);
-                  gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
-                  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-                  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-                  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-                  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-                  gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, portrait);
-                  gl.uniform1i(imageUniform, 0);
-                  gl.uniform2f(imageSize, portrait.naturalWidth, portrait.naturalHeight);
-
-                  resize();
-                  textureReady = true;
-                  stage.dataset.portraitState = "ready";
-                  draw(0);
-                } catch {
-                  setFallback();
-                }
-              };
-
-              const updatePointer = (event: PointerEvent) => {
-                const width = canvas.clientWidth;
-                const height = canvas.clientHeight;
-                if (width === 0 || height === 0) return;
-                targetPointer.x = (event.offsetX / width) * 2 - 1;
-                targetPointer.y = 1 - (event.offsetY / height) * 2;
-              };
-
-              canvas.addEventListener(
-                "pointermove",
-                (event) => {
-                  updatePointer(event);
-                  if (event.pointerType === "mouse" || event.buttons > 0) {
-                    targetInteraction = 1;
-                  }
-                },
-                { passive: true },
-              );
-              canvas.addEventListener(
-                "pointerdown",
-                (event) => {
-                  if (reducedMotion.matches) return;
-                  updatePointer(event);
-                  pulse = 1;
-                  targetInteraction = 1;
-                },
-                { passive: true },
-              );
-              canvas.addEventListener("pointerup", () => {
-                targetInteraction = 0;
-              });
-              canvas.addEventListener("pointerleave", () => {
-                targetInteraction = 0;
-                targetPointer.x = 0.22;
-                targetPointer.y = -0.18;
-              });
-              canvas.addEventListener("pointercancel", () => {
-                targetInteraction = 0;
-              });
-
-              canvas.addEventListener("webglcontextlost", (event) => {
-                event.preventDefault();
-                textureReady = false;
-                cancelAnimationFrame(animationFrame);
+              if (!buffer || !texture) {
+                if (buffer) gl.deleteBuffer(buffer);
+                if (texture) gl.deleteTexture(texture);
+                gl.deleteProgram(program);
                 setFallback();
-              });
+              } else {
+                const position = gl.getAttribLocation(program, "aPosition");
+                const imageUniform = gl.getUniformLocation(program, "uImage");
+                const resolution = gl.getUniformLocation(program, "uResolution");
+                const uvScaleUniform = gl.getUniformLocation(program, "uUvScale");
+                const uvOffsetUniform = gl.getUniformLocation(program, "uUvOffset");
+                const aspectScaleUniform = gl.getUniformLocation(program, "uAspectScale");
+                const pointerUniform = gl.getUniformLocation(program, "uPointer");
+                const interactionUniform = gl.getUniformLocation(program, "uInteraction");
+                const pulseUniform = gl.getUniformLocation(program, "uPulse");
+                const timeUniform = gl.getUniformLocation(program, "uTime");
+                const uvScale = { x: 1, y: 1 };
+                const uvOffset = { x: 0, y: 0 };
+                const aspectScale = { x: 1, y: 1 };
+                const pointer = { x: 0.22, y: -0.18 };
+                const targetPointer = { ...pointer };
+                const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+                let animationFrame = 0;
+                let isVisible = true;
+                let textureReady = false;
+                let interaction = 0;
+                let targetInteraction = 0;
+                let pulse = 0;
+                let previousMilliseconds: number | null = null;
 
-              const visibilityObserver = new IntersectionObserver(([entry]) => {
-                isVisible = entry?.isIntersecting ?? false;
-                cancelAnimationFrame(animationFrame);
-                if (isVisible && textureReady) animationFrame = requestAnimationFrame(draw);
-              });
+                gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+                gl.bufferData(
+                  gl.ARRAY_BUFFER,
+                  new Float32Array([-1, -1, 3, -1, -1, 3]),
+                  gl.STATIC_DRAW,
+                );
+                gl.useProgram(program);
+                gl.enableVertexAttribArray(position);
+                gl.vertexAttribPointer(position, 2, gl.FLOAT, false, 0, 0);
 
-              visibilityObserver.observe(stage);
-              new ResizeObserver(() => {
-                resize();
-                if (!isVisible || reducedMotion.matches) draw(previousMilliseconds ?? 0);
-              }).observe(stage);
-              reducedMotion.addEventListener("change", () => {
-                cancelAnimationFrame(animationFrame);
-                interaction = 0;
-                targetInteraction = 0;
-                pulse = 0;
-                previousMilliseconds = null;
-                draw(0);
-              });
+                const resize = () => {
+                  const dpr = Math.min(window.devicePixelRatio, 1.6);
+                  const width = Math.max(1, Math.round(canvas.clientWidth * dpr));
+                  const height = Math.max(1, Math.round(canvas.clientHeight * dpr));
 
-              void uploadPortrait();
+                  if (canvas.width !== width || canvas.height !== height) {
+                    canvas.width = width;
+                    canvas.height = height;
+                    gl.viewport(0, 0, width, height);
+                  }
+
+                  const aspect = width / height;
+                  const imageAspect = portrait.naturalWidth / Math.max(portrait.naturalHeight, 1);
+                  aspectScale.x = aspect;
+
+                  if (aspect > imageAspect) {
+                    const visibleHeight = imageAspect / aspect;
+                    uvScale.x = 1;
+                    uvScale.y = visibleHeight;
+                    uvOffset.x = 0;
+                    uvOffset.y = 0.56 - 0.5 * visibleHeight;
+                  } else {
+                    const visibleWidth = aspect / imageAspect;
+                    uvScale.x = visibleWidth;
+                    uvScale.y = 1;
+                    uvOffset.x = 0.5 - 0.5 * visibleWidth;
+                    uvOffset.y = 0;
+                  }
+                };
+
+                const draw = (milliseconds: number) => {
+                  if (!textureReady) return;
+                  const deltaSeconds =
+                    previousMilliseconds !== null
+                      ? Math.min((milliseconds - previousMilliseconds) / 1000, 0.05)
+                      : 0;
+                  previousMilliseconds = milliseconds;
+                  pointer.x += (targetPointer.x - pointer.x) * 0.055;
+                  pointer.y += (targetPointer.y - pointer.y) * 0.055;
+                  interaction +=
+                    (targetInteraction - interaction) * (1 - Math.exp(-deltaSeconds * 11));
+                  pulse = Math.max(0, pulse - deltaSeconds * 1.8);
+
+                  gl.uniform2f(resolution, canvas.width, canvas.height);
+                  gl.uniform2f(uvScaleUniform, uvScale.x, uvScale.y);
+                  gl.uniform2f(uvOffsetUniform, uvOffset.x, uvOffset.y);
+                  gl.uniform2f(aspectScaleUniform, aspectScale.x, aspectScale.y);
+                  gl.uniform2f(pointerUniform, pointer.x, pointer.y);
+                  gl.uniform1f(interactionUniform, interaction);
+                  gl.uniform1f(pulseUniform, pulse);
+                  gl.uniform1f(timeUniform, (milliseconds / 1000) % 3600);
+                  gl.drawArrays(gl.TRIANGLES, 0, 3);
+
+                  if (isVisible && !reducedMotion.matches) {
+                    animationFrame = requestAnimationFrame(draw);
+                  }
+                };
+
+                const uploadPortrait = async () => {
+                  try {
+                    if (!portrait.complete || portrait.naturalWidth === 0) {
+                      await portrait.decode();
+                    }
+
+                    gl.activeTexture(gl.TEXTURE0);
+                    gl.bindTexture(gl.TEXTURE_2D, texture);
+                    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+                    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+                    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+                    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+                    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+                    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, portrait);
+                    gl.uniform1i(imageUniform, 0);
+
+                    resize();
+                    textureReady = true;
+                    stage.dataset.portraitState = "ready";
+                    draw(0);
+                  } catch {
+                    setFallback();
+                  }
+                };
+
+                const updatePointer = (event: PointerEvent) => {
+                  const width = canvas.clientWidth;
+                  const height = canvas.clientHeight;
+                  if (width === 0 || height === 0) return;
+                  targetPointer.x = (event.offsetX / width) * 2 - 1;
+                  targetPointer.y = 1 - (event.offsetY / height) * 2;
+                };
+
+                canvas.addEventListener(
+                  "pointermove",
+                  (event) => {
+                    updatePointer(event);
+                    if (event.pointerType === "mouse" || event.buttons > 0) {
+                      targetInteraction = 1;
+                    }
+                  },
+                  { passive: true },
+                );
+                canvas.addEventListener(
+                  "pointerdown",
+                  (event) => {
+                    if (reducedMotion.matches) return;
+                    updatePointer(event);
+                    pulse = 1;
+                    targetInteraction = 1;
+                  },
+                  { passive: true },
+                );
+                canvas.addEventListener("pointerup", () => {
+                  targetInteraction = 0;
+                });
+                canvas.addEventListener("pointerleave", () => {
+                  targetInteraction = 0;
+                  targetPointer.x = 0.22;
+                  targetPointer.y = -0.18;
+                });
+                canvas.addEventListener("pointercancel", () => {
+                  targetInteraction = 0;
+                });
+
+                canvas.addEventListener("webglcontextlost", (event) => {
+                  event.preventDefault();
+                  textureReady = false;
+                  cancelAnimationFrame(animationFrame);
+                  setFallback();
+                });
+
+                const visibilityObserver = new IntersectionObserver(([entry]) => {
+                  isVisible = entry?.isIntersecting ?? false;
+                  cancelAnimationFrame(animationFrame);
+                  if (isVisible && textureReady) animationFrame = requestAnimationFrame(draw);
+                });
+
+                visibilityObserver.observe(stage);
+                new ResizeObserver(() => {
+                  resize();
+                  if (!isVisible || reducedMotion.matches) draw(previousMilliseconds ?? 0);
+                }).observe(stage);
+                reducedMotion.addEventListener("change", () => {
+                  cancelAnimationFrame(animationFrame);
+                  interaction = 0;
+                  targetInteraction = 0;
+                  pulse = 0;
+                  previousMilliseconds = null;
+                  draw(0);
+                });
+
+                void uploadPortrait();
+              }
             }
           }
         }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -383,13 +383,23 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
           const program = gl.createProgram();
 
           if (!vertexShader || !fragmentShader || !program) {
+            if (vertexShader) gl.deleteShader(vertexShader);
+            if (fragmentShader) gl.deleteShader(fragmentShader);
+            if (program) gl.deleteProgram(program);
             setFallback();
           } else {
             gl.attachShader(program, vertexShader);
             gl.attachShader(program, fragmentShader);
             gl.linkProgram(program);
 
-            if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+            const linked = gl.getProgramParameter(program, gl.LINK_STATUS);
+            gl.detachShader(program, vertexShader);
+            gl.detachShader(program, fragmentShader);
+            gl.deleteShader(vertexShader);
+            gl.deleteShader(fragmentShader);
+
+            if (!linked) {
+              gl.deleteProgram(program);
               setFallback();
             } else {
               const buffer = gl.createBuffer();
@@ -492,6 +502,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
 
               const updatePointer = (event: PointerEvent) => {
                 const bounds = canvas.getBoundingClientRect();
+                if (bounds.width === 0 || bounds.height === 0) return;
                 targetPointer.x = ((event.clientX - bounds.left) / bounds.width) * 2 - 1;
                 targetPointer.y = 1 - ((event.clientY - bounds.top) / bounds.height) * 2;
               };
@@ -576,6 +587,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
           "pointermove",
           (event) => {
             const bounds = hero.getBoundingClientRect();
+            if (bounds.width === 0 || bounds.height === 0) return;
             pointerX = ((event.clientX - bounds.left) / bounds.width) * 100;
             pointerY = ((event.clientY - bounds.top) / bounds.height) * 100;
             if (!pointerFrame) pointerFrame = requestAnimationFrame(renderHeroPointer);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -490,8 +490,9 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
                       ? Math.max(0, Math.min((milliseconds - previousMilliseconds) / 1000, 0.05))
                       : 0;
                   previousMilliseconds = milliseconds;
-                  pointer.x += (targetPointer.x - pointer.x) * 0.055;
-                  pointer.y += (targetPointer.y - pointer.y) * 0.055;
+                  const pointerLerp = 1 - Math.exp(-deltaSeconds * 3.4);
+                  pointer.x += (targetPointer.x - pointer.x) * pointerLerp;
+                  pointer.y += (targetPointer.y - pointer.y) * pointerLerp;
                   interaction +=
                     (targetInteraction - interaction) * (1 - Math.exp(-deltaSeconds * 11));
                   pulse = Math.max(0, pulse - deltaSeconds * 1.8);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -83,7 +83,8 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
 
         <div class="hero-copy">
           <p class="hero-role">Developer, interface maker, systems thinker.</p>
-          <h1 id="hero-title" aria-label={profile.headline}>
+          <h1 id="hero-title">
+            <span class="sr-only">{profile.headline}</span>
             {
               headlineLines.map((line) => (
                 <span class="headline-mask" aria-hidden="true">
@@ -202,7 +203,12 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
           powerPreference: "low-power",
         });
 
+        let cleanupPortrait: (() => void) | undefined;
+
         const setFallback = () => {
+          const cleanup = cleanupPortrait;
+          cleanupPortrait = undefined;
+          cleanup?.();
           stage.dataset.portraitState = "fallback";
         };
 
@@ -420,6 +426,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
                 const pointer = { x: 0.22, y: -0.18 };
                 const targetPointer = { ...pointer };
                 const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+                const eventController = new AbortController();
                 let animationFrame = 0;
                 let isVisible = true;
                 let textureReady = false;
@@ -534,7 +541,10 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
                   targetPointer.y = 1 - ((event.clientY - bounds.top) / bounds.height) * 2;
                 };
 
-                canvas.addEventListener("pointerenter", measureCanvas, { passive: true });
+                canvas.addEventListener("pointerenter", measureCanvas, {
+                  passive: true,
+                  signal: eventController.signal,
+                });
 
                 canvas.addEventListener(
                   "pointermove",
@@ -544,7 +554,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
                       targetInteraction = 1;
                     }
                   },
-                  { passive: true },
+                  { passive: true, signal: eventController.signal },
                 );
                 canvas.addEventListener(
                   "pointerdown",
@@ -555,29 +565,48 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
                     pulse = 1;
                     targetInteraction = 1;
                   },
-                  { passive: true },
+                  { passive: true, signal: eventController.signal },
                 );
-                canvas.addEventListener("pointerup", () => {
-                  targetInteraction = 0;
+                canvas.addEventListener(
+                  "pointerup",
+                  () => {
+                    targetInteraction = 0;
+                  },
+                  { signal: eventController.signal },
+                );
+                canvas.addEventListener(
+                  "pointerleave",
+                  () => {
+                    targetInteraction = 0;
+                    canvasBounds = null;
+                    targetPointer.x = 0.22;
+                    targetPointer.y = -0.18;
+                  },
+                  { signal: eventController.signal },
+                );
+                canvas.addEventListener(
+                  "pointercancel",
+                  () => {
+                    targetInteraction = 0;
+                    canvasBounds = null;
+                  },
+                  { signal: eventController.signal },
+                );
+                window.addEventListener("scroll", () => (canvasBounds = null), {
+                  passive: true,
+                  signal: eventController.signal,
                 });
-                canvas.addEventListener("pointerleave", () => {
-                  targetInteraction = 0;
-                  canvasBounds = null;
-                  targetPointer.x = 0.22;
-                  targetPointer.y = -0.18;
-                });
-                canvas.addEventListener("pointercancel", () => {
-                  targetInteraction = 0;
-                  canvasBounds = null;
-                });
-                window.addEventListener("scroll", () => (canvasBounds = null), { passive: true });
 
-                canvas.addEventListener("webglcontextlost", (event) => {
-                  event.preventDefault();
-                  textureReady = false;
-                  cancelAnimationFrame(animationFrame);
-                  setFallback();
-                });
+                canvas.addEventListener(
+                  "webglcontextlost",
+                  (event) => {
+                    event.preventDefault();
+                    textureReady = false;
+                    cancelAnimationFrame(animationFrame);
+                    setFallback();
+                  },
+                  { signal: eventController.signal },
+                );
 
                 const visibilityObserver = new IntersectionObserver(([entry]) => {
                   isVisible = entry?.isIntersecting ?? false;
@@ -586,19 +615,38 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
                 });
 
                 visibilityObserver.observe(stage);
-                new ResizeObserver(() => {
+                const resizeObserver = new ResizeObserver(() => {
                   canvasBounds = null;
                   resize();
                   if (!isVisible || reducedMotion.matches) draw(previousMilliseconds ?? 0);
-                }).observe(stage);
-                reducedMotion.addEventListener("change", () => {
-                  cancelAnimationFrame(animationFrame);
-                  interaction = 0;
-                  targetInteraction = 0;
-                  pulse = 0;
-                  previousMilliseconds = null;
-                  draw(0);
                 });
+                resizeObserver.observe(stage);
+                reducedMotion.addEventListener(
+                  "change",
+                  () => {
+                    cancelAnimationFrame(animationFrame);
+                    interaction = 0;
+                    targetInteraction = 0;
+                    pulse = 0;
+                    previousMilliseconds = null;
+                    draw(0);
+                  },
+                  { signal: eventController.signal },
+                );
+
+                cleanupPortrait = () => {
+                  textureReady = false;
+                  cancelAnimationFrame(animationFrame);
+                  visibilityObserver.disconnect();
+                  resizeObserver.disconnect();
+                  eventController.abort();
+
+                  if (!gl.isContextLost()) {
+                    gl.deleteTexture(texture);
+                    gl.deleteBuffer(buffer);
+                    gl.deleteProgram(program);
+                  }
+                };
 
                 void uploadPortrait();
               }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -657,6 +657,15 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
                   }
                 };
 
+                document.addEventListener("astro:before-swap", setFallback, {
+                  once: true,
+                  signal: eventController.signal,
+                });
+                window.addEventListener("pagehide", setFallback, {
+                  once: true,
+                  signal: eventController.signal,
+                });
+
                 void uploadPortrait();
               }
             }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -196,12 +196,19 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
         stage instanceof HTMLElement &&
         portrait instanceof HTMLImageElement
       ) {
-        const gl = canvas.getContext("webgl2", {
-          alpha: false,
-          antialias: false,
-          depth: false,
-          powerPreference: "low-power",
-        });
+        const gl = (() => {
+          try {
+            return canvas.getContext("webgl2", {
+              alpha: false,
+              antialias: false,
+              depth: false,
+              powerPreference: "low-power",
+            });
+          } catch (error) {
+            console.error("WebGL2 context creation failed:", error);
+            return null;
+          }
+        })();
 
         let cleanupPortrait: (() => void) | undefined;
 
@@ -480,7 +487,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
                   if (!textureReady) return;
                   const deltaSeconds =
                     previousMilliseconds !== null
-                      ? Math.min((milliseconds - previousMilliseconds) / 1000, 0.05)
+                      ? Math.max(0, Math.min((milliseconds - previousMilliseconds) / 1000, 0.05))
                       : 0;
                   previousMilliseconds = milliseconds;
                   pointer.x += (targetPointer.x - pointer.x) * 0.055;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -307,7 +307,6 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
               bloom += imageAt(curvedUv - pixel);
               bloom *= 0.1667;
 
-              float bloomLuma = dot(bloom, vec3(0.2126, 0.7152, 0.0722));
               vec3 halation = max(bloom - 0.42, 0.0) * vec3(0.78, 0.22, 0.12) * 0.62;
               vec3 color = mix(base, bloom, 0.12) + halation;
 
@@ -668,11 +667,14 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
       const hero = document.querySelector(".hero");
       const reducedMotionPreference = window.matchMedia("(prefers-reduced-motion: reduce)");
 
-      if (hero instanceof HTMLElement && !reducedMotionPreference.matches) {
+      if (hero instanceof HTMLElement) {
         let pointerFrame = 0;
         let pointerX = 72;
         let pointerY = 42;
         let cachedBounds: DOMRect | null = null;
+        let parallaxController: AbortController | null = null;
+        let heroResizeObserver: ResizeObserver | null = null;
+        const lifecycleController = new AbortController();
 
         const renderHeroPointer = () => {
           hero.style.setProperty("--pointer-x", `${pointerX}%`);
@@ -686,36 +688,87 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
           cachedBounds = null;
         };
 
-        hero.addEventListener(
-          "pointerenter",
-          () => {
-            cachedBounds = hero.getBoundingClientRect();
-          },
-          { passive: true },
-        );
-
-        hero.addEventListener(
-          "pointermove",
-          (event) => {
-            const bounds = cachedBounds ?? hero.getBoundingClientRect();
-            cachedBounds = bounds;
-            if (bounds.width === 0 || bounds.height === 0) return;
-            pointerX = ((event.clientX - bounds.left) / bounds.width) * 100;
-            pointerY = ((event.clientY - bounds.top) / bounds.height) * 100;
-            if (!pointerFrame) pointerFrame = requestAnimationFrame(renderHeroPointer);
-          },
-          { passive: true },
-        );
-
-        hero.addEventListener("pointerleave", () => {
+        const stopParallax = () => {
+          parallaxController?.abort();
+          parallaxController = null;
+          heroResizeObserver?.disconnect();
+          heroResizeObserver = null;
+          cancelAnimationFrame(pointerFrame);
+          pointerFrame = 0;
           clearCachedBounds();
           pointerX = 72;
           pointerY = 42;
-          if (!pointerFrame) pointerFrame = requestAnimationFrame(renderHeroPointer);
-        });
+          hero.style.removeProperty("--pointer-x");
+          hero.style.removeProperty("--pointer-y");
+          hero.style.removeProperty("--parallax-x");
+          hero.style.removeProperty("--parallax-y");
+        };
 
-        window.addEventListener("scroll", clearCachedBounds, { passive: true });
-        new ResizeObserver(clearCachedBounds).observe(hero);
+        const startParallax = () => {
+          if (parallaxController || reducedMotionPreference.matches) return;
+
+          parallaxController = new AbortController();
+          const { signal } = parallaxController;
+
+          hero.addEventListener(
+            "pointerenter",
+            () => {
+              cachedBounds = hero.getBoundingClientRect();
+            },
+            { passive: true, signal },
+          );
+
+          hero.addEventListener(
+            "pointermove",
+            (event) => {
+              const bounds = cachedBounds ?? hero.getBoundingClientRect();
+              cachedBounds = bounds;
+              if (bounds.width === 0 || bounds.height === 0) return;
+              pointerX = ((event.clientX - bounds.left) / bounds.width) * 100;
+              pointerY = ((event.clientY - bounds.top) / bounds.height) * 100;
+              if (!pointerFrame) pointerFrame = requestAnimationFrame(renderHeroPointer);
+            },
+            { passive: true, signal },
+          );
+
+          hero.addEventListener(
+            "pointerleave",
+            () => {
+              clearCachedBounds();
+              pointerX = 72;
+              pointerY = 42;
+              if (!pointerFrame) pointerFrame = requestAnimationFrame(renderHeroPointer);
+            },
+            { passive: true, signal },
+          );
+
+          window.addEventListener("scroll", clearCachedBounds, { passive: true, signal });
+          heroResizeObserver = new ResizeObserver(clearCachedBounds);
+          heroResizeObserver.observe(hero);
+        };
+
+        const syncParallax = () => {
+          if (reducedMotionPreference.matches) stopParallax();
+          else startParallax();
+        };
+
+        const disposeParallax = () => {
+          stopParallax();
+          lifecycleController.abort();
+        };
+
+        reducedMotionPreference.addEventListener("change", syncParallax, {
+          signal: lifecycleController.signal,
+        });
+        window.addEventListener("pagehide", disposeParallax, {
+          once: true,
+          signal: lifecycleController.signal,
+        });
+        document.addEventListener("astro:before-swap", disposeParallax, {
+          once: true,
+          signal: lifecycleController.signal,
+        });
+        syncParallax();
       }
     </script>
   </body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -233,6 +233,9 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
             in vec2 vUv;
             out vec4 outColor;
 
+            vec2 uvScale;
+            vec2 uvOffset;
+
             float hash(vec2 p) {
               p = fract(p * vec2(123.34, 345.45));
               p += dot(p, p + 34.345);
@@ -240,18 +243,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
             }
 
             vec2 coverUv(vec2 uv) {
-              float screenAspect = uResolution.x / max(uResolution.y, 1.0);
-              float imageAspect = uImageSize.x / max(uImageSize.y, 1.0);
-
-              if (screenAspect > imageAspect) {
-                float visibleHeight = imageAspect / screenAspect;
-                uv.y = 0.56 + (uv.y - 0.5) * visibleHeight;
-              } else {
-                float visibleWidth = screenAspect / imageAspect;
-                uv.x = 0.5 + (uv.x - 0.5) * visibleWidth;
-              }
-
-              return clamp(uv, 0.001, 0.999);
+              return clamp(uv * uvScale + uvOffset, 0.001, 0.999);
             }
 
             vec3 imageAt(vec2 uv) {
@@ -259,6 +251,20 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
             }
 
             void main() {
+              float aspect = uResolution.x / max(uResolution.y, 1.0);
+              float imageAspect = uImageSize.x / max(uImageSize.y, 1.0);
+
+              if (aspect > imageAspect) {
+                float visibleHeight = imageAspect / aspect;
+                uvScale = vec2(1.0, visibleHeight);
+                uvOffset = vec2(0.0, 0.56 - 0.5 * visibleHeight);
+              } else {
+                float visibleWidth = aspect / imageAspect;
+                uvScale = vec2(visibleWidth, 1.0);
+                uvOffset = vec2(0.5 - 0.5 * visibleWidth, 0.0);
+              }
+
+              vec2 aspectScale = vec2(aspect, 1.0);
               float time = uTime;
               vec2 centered = vUv * 2.0 - 1.0;
               float radiusSquared = dot(centered, centered);
@@ -269,7 +275,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
               float glassEdge = smoothstep(-0.018, 0.035, edge);
 
               vec2 pointerUv = uPointer * 0.5 + 0.5;
-              vec2 pointerDelta = (vUv - pointerUv) * vec2(uResolution.x / uResolution.y, 1.0);
+              vec2 pointerDelta = (vUv - pointerUv) * aspectScale;
               float pointerDistance = length(pointerDelta);
               float interactionField = exp(-pointerDistance * 4.6) * uInteraction;
               float pulseField = exp(-pointerDistance * 3.2) * uPulse;
@@ -345,7 +351,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
               float pulseRing = exp(-abs(pointerDistance - pulseRadius) * 36.0) * uPulse;
               color += vec3(1.0, 0.24, 0.12) * pulseRing * 0.2;
 
-              vec2 reflectionDelta = (vUv - vec2(0.7, 0.16)) * vec2(uResolution.x / uResolution.y, 1.0);
+              vec2 reflectionDelta = (vUv - vec2(0.7, 0.16)) * aspectScale;
               float glassReflection = exp(-length(reflectionDelta) * 5.2);
               color += vec3(1.0, 0.72, 0.58) * glassReflection * 0.085;
 
@@ -371,6 +377,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
             gl.compileShader(shader);
 
             if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+              console.error("Shader compilation failed:", gl.getShaderInfoLog(shader));
               gl.deleteShader(shader);
               return null;
             }
@@ -399,6 +406,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
             gl.deleteShader(fragmentShader);
 
             if (!linked) {
+              console.error("Program linking failed:", gl.getProgramInfoLog(program));
               gl.deleteProgram(program);
               setFallback();
             } else {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -521,7 +521,9 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
                 "pointermove",
                 (event) => {
                   updatePointer(event);
-                  if (event.pointerType === "mouse") targetInteraction = 1;
+                  if (event.pointerType === "mouse" || event.buttons > 0) {
+                    targetInteraction = 1;
+                  }
                 },
                 { passive: true },
               );
@@ -531,12 +533,15 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
                   if (reducedMotion.matches) return;
                   updatePointer(event);
                   pulse = 1;
-                  if (event.pointerType === "mouse") targetInteraction = 1;
+                  targetInteraction = 1;
                 },
                 { passive: true },
               );
-              canvas.addEventListener("pointerleave", (event) => {
-                if (event.pointerType === "mouse") targetInteraction = 0;
+              canvas.addEventListener("pointerup", () => {
+                targetInteraction = 0;
+              });
+              canvas.addEventListener("pointerleave", () => {
+                targetInteraction = 0;
                 targetPointer.x = 0.22;
                 targetPointer.y = -0.18;
               });

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -518,6 +518,8 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
                       await portrait.decode();
                     }
 
+                    if (!cleanupPortrait) return;
+
                     gl.activeTexture(gl.TEXTURE0);
                     gl.bindTexture(gl.TEXTURE_2D, texture);
                     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -427,6 +427,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
                 let targetInteraction = 0;
                 let pulse = 0;
                 let previousMilliseconds: number | null = null;
+                let canvasBounds: DOMRect | null = null;
 
                 gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
                 gl.bufferData(
@@ -521,13 +522,19 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
                   }
                 };
 
-                const updatePointer = (event: PointerEvent) => {
-                  const width = canvas.clientWidth;
-                  const height = canvas.clientHeight;
-                  if (width === 0 || height === 0) return;
-                  targetPointer.x = (event.offsetX / width) * 2 - 1;
-                  targetPointer.y = 1 - (event.offsetY / height) * 2;
+                const measureCanvas = () => {
+                  canvasBounds = canvas.getBoundingClientRect();
+                  return canvasBounds;
                 };
+
+                const updatePointer = (event: PointerEvent) => {
+                  const bounds = canvasBounds ?? measureCanvas();
+                  if (bounds.width === 0 || bounds.height === 0) return;
+                  targetPointer.x = ((event.clientX - bounds.left) / bounds.width) * 2 - 1;
+                  targetPointer.y = 1 - ((event.clientY - bounds.top) / bounds.height) * 2;
+                };
+
+                canvas.addEventListener("pointerenter", measureCanvas, { passive: true });
 
                 canvas.addEventListener(
                   "pointermove",
@@ -543,6 +550,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
                   "pointerdown",
                   (event) => {
                     if (reducedMotion.matches) return;
+                    measureCanvas();
                     updatePointer(event);
                     pulse = 1;
                     targetInteraction = 1;
@@ -554,12 +562,15 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
                 });
                 canvas.addEventListener("pointerleave", () => {
                   targetInteraction = 0;
+                  canvasBounds = null;
                   targetPointer.x = 0.22;
                   targetPointer.y = -0.18;
                 });
                 canvas.addEventListener("pointercancel", () => {
                   targetInteraction = 0;
+                  canvasBounds = null;
                 });
+                window.addEventListener("scroll", () => (canvasBounds = null), { passive: true });
 
                 canvas.addEventListener("webglcontextlost", (event) => {
                   event.preventDefault();
@@ -576,6 +587,7 @@ const headlineLines = [["Make"], ["complex", "work"], ["feel", "obvious."]];
 
                 visibilityObserver.observe(stage);
                 new ResizeObserver(() => {
+                  canvasBounds = null;
                   resize();
                   if (!isVisible || reducedMotion.matches) draw(previousMilliseconds ?? 0);
                 }).observe(stage);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -38,6 +38,18 @@ body {
   background: var(--paper);
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 a {
   color: inherit;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1030,10 +1030,12 @@ h1 {
   *,
   *::before,
   *::after {
-    animation-duration: 0.001ms !important;
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
     animation-iteration-count: 1 !important;
     scroll-behavior: auto !important;
-    transition-duration: 0.001ms !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
   }
 
   .hero-light-field {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,20 +1,18 @@
 :root {
   color-scheme: light;
-  --paper: oklch(96.5% 0.017 137);
-  --paper-warm: oklch(94.5% 0.027 76);
-  --paper-cool: oklch(91.5% 0.038 205);
-  --surface: oklch(97.8% 0.011 118 / 94%);
-  --surface-strong: oklch(92.5% 0.029 176 / 72%);
-  --ink: oklch(18.5% 0.036 184);
-  --ink-soft: oklch(39% 0.035 184);
-  --line: oklch(72% 0.032 137 / 70%);
-  --moss: oklch(41% 0.082 145);
-  --cyan: oklch(58% 0.112 214);
-  --rust: oklch(50% 0.147 26);
-  --shadow: oklch(33% 0.055 150 / 18%);
+  --paper: oklch(97% 0.006 285);
+  --paper-cool: oklch(92% 0.018 285);
+  --ink: oklch(17% 0.035 288);
+  --ink-soft: oklch(39% 0.038 286);
+  --lacquer: oklch(54% 0.22 25);
+  --lacquer-dark: oklch(38% 0.16 22);
+  --blush: oklch(79% 0.105 21);
+  --gold: oklch(79% 0.16 72);
+  --line: oklch(17% 0.035 288 / 18%);
   --font-body:
     Aptos, "Avenir Next", "Segoe UI", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
     sans-serif;
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 * {
@@ -22,632 +20,1017 @@
 }
 
 html {
+  min-width: 320px;
   min-height: 100%;
   color: var(--ink);
   font-family: var(--font-body);
   font-size: 16px;
   line-height: 1.5;
   background: var(--paper);
+  scroll-behavior: smooth;
   text-rendering: geometricPrecision;
 }
 
 body {
-  position: relative;
   min-height: 100svh;
   margin: 0;
   overflow-x: hidden;
-  background:
-    linear-gradient(122deg, oklch(79% 0.07 149 / 30%) 0 24%, transparent 24% 100%),
-    linear-gradient(318deg, oklch(73% 0.1 24 / 21%) 0 22%, transparent 22% 100%),
-    linear-gradient(145deg, var(--paper-warm), var(--paper) 44%, var(--paper-cool));
-  isolation: isolate;
-}
-
-body::before {
-  position: fixed;
-  inset: 0;
-  z-index: -2;
-  pointer-events: none;
-  content: "";
-  background-image:
-    linear-gradient(oklch(51% 0.04 130 / 11%) 1px, transparent 1px),
-    linear-gradient(90deg, oklch(51% 0.04 130 / 11%) 1px, transparent 1px);
-  background-size: 28px 28px;
-  mask-image: linear-gradient(125deg, black 0 36%, transparent 78%);
-  animation: field-drift 28s linear infinite;
+  background: var(--paper);
 }
 
 a {
   color: inherit;
 }
 
-.ambient-field {
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  overflow: hidden;
-  pointer-events: none;
+h1,
+h2,
+p {
+  text-wrap: pretty;
 }
 
-.ambient-field::before,
-.ambient-field::after {
-  position: absolute;
-  content: "";
+h1,
+h2 {
+  text-wrap: balance;
 }
 
-.ambient-field::before {
-  inset: 9% 5% 12% 49%;
-  background-image: radial-gradient(circle, oklch(43% 0.06 174 / 20%) 1.4px, transparent 1.6px);
-  background-size: 18px 18px;
-  mask-image: linear-gradient(116deg, transparent, black 32% 64%, transparent);
-  animation: dot-breathe 9s cubic-bezier(0.16, 1, 0.3, 1) infinite;
+.site-header,
+.hero,
+.site-footer {
+  width: min(100% - 48px, 1440px);
+  margin-inline: auto;
 }
 
-.ambient-field::after {
-  top: 12%;
-  right: -14%;
-  width: min(52vw, 680px);
-  height: 58%;
-  border: 1px solid oklch(53% 0.08 207 / 15%);
-  background:
-    linear-gradient(120deg, oklch(87% 0.055 202 / 24%), transparent 68%),
-    linear-gradient(90deg, transparent, oklch(96% 0.015 120 / 22%));
-  clip-path: polygon(14% 0, 100% 18%, 78% 100%, 0 76%);
-  animation: quiet-float 18s cubic-bezier(0.16, 1, 0.3, 1) infinite alternate;
-}
-
-.ambient-node,
-.ambient-plane {
-  position: absolute;
-  display: block;
-}
-
-.ambient-node {
-  width: 10px;
-  height: 10px;
-  border: 2px solid currentColor;
-  border-radius: 999px;
-  background: var(--paper);
-  box-shadow: 0 0 0 8px currentColor;
-  opacity: 0.2;
-  animation: lamp-breathe 7s cubic-bezier(0.16, 1, 0.3, 1) infinite;
-}
-
-.ambient-node-a {
-  top: 24%;
-  left: 13%;
-  color: oklch(41% 0.082 145 / 18%);
-}
-
-.ambient-node-b {
-  right: 15%;
-  bottom: 23%;
-  color: oklch(58% 0.112 214 / 16%);
-  animation-delay: -2.3s;
-}
-
-.ambient-node-c {
-  top: 61%;
-  left: 44%;
-  color: oklch(50% 0.147 26 / 14%);
-  animation-delay: -4.6s;
-}
-
-.ambient-plane {
-  border: 1px solid oklch(36% 0.04 164 / 13%);
-  background: oklch(97% 0.011 118 / 24%);
-  animation: plane-drift 22s cubic-bezier(0.16, 1, 0.3, 1) infinite alternate;
-}
-
-.ambient-plane-a {
-  top: 69%;
-  left: 8%;
-  width: 24vw;
-  max-width: 340px;
-  height: 120px;
-  clip-path: polygon(9% 12%, 100% 0, 82% 82%, 0 100%);
-}
-
-.ambient-plane-b {
-  top: 5%;
-  right: 26%;
-  width: 18vw;
-  max-width: 260px;
-  height: 96px;
-  border-color: oklch(50% 0.09 26 / 13%);
-  background: oklch(86% 0.06 27 / 14%);
-  clip-path: polygon(0 0, 100% 14%, 86% 100%, 8% 76%);
-  animation-delay: -8s;
-}
-
-.page-shell {
-  position: relative;
-  z-index: 1;
-  width: 100%;
-  min-width: 0;
+.site-header {
+  min-height: 86px;
   display: grid;
-  min-height: 100svh;
-  place-items: center;
-  padding: clamp(20px, 5vw, 72px);
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 28px;
+  border-bottom: 1px solid var(--line);
 }
 
-.profile-card {
+.wordmark {
+  width: fit-content;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 10px;
+  text-decoration: none;
+}
+
+.wordmark span {
+  font-size: 1rem;
+  font-weight: 850;
+  letter-spacing: -0.02em;
+}
+
+.wordmark small {
+  color: var(--lacquer);
+  font-size: 0.72rem;
+  font-weight: 760;
+}
+
+.header-nav {
+  display: flex;
+  gap: 28px;
+}
+
+.header-nav a {
+  font-size: 0.8rem;
+  font-weight: 720;
+  text-decoration: none;
+  transition: color 180ms var(--ease-out);
+}
+
+.header-nav a:hover,
+.header-nav a:focus-visible {
+  color: var(--lacquer);
+}
+
+.availability {
+  display: flex;
+  align-items: center;
+  justify-self: end;
+  gap: 9px;
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.76rem;
+  font-weight: 650;
+}
+
+.availability-dot {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: var(--lacquer);
+  animation: status-pulse 2.8s ease-in-out infinite;
+}
+
+.availability-short {
+  display: none;
+}
+
+.hero {
+  --pointer-x: 72%;
+  --pointer-y: 42%;
+  --parallax-x: 0px;
+  --parallax-y: 0px;
   position: relative;
-  width: 100%;
-  max-width: 1080px;
-  min-width: 0;
-  min-height: min(620px, calc(100svh - clamp(40px, 10vw, 144px)));
+  min-height: calc(100svh - 86px);
   display: grid;
-  grid-template-areas:
-    "identity signal"
-    "links links"
-    "footer footer";
-  grid-template-columns: minmax(0, 0.98fr) minmax(260px, 0.72fr);
-  align-content: space-between;
-  gap: clamp(30px, 5vw, 64px) clamp(34px, 6vw, 82px);
-  padding: clamp(28px, 5vw, 64px);
-  overflow: hidden;
-  background:
-    linear-gradient(132deg, var(--surface), oklch(94% 0.025 190 / 88%)),
-    linear-gradient(90deg, transparent 0 66%, oklch(86% 0.055 187 / 22%) 66% 100%);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  box-shadow: 0 28px 90px var(--shadow);
+  grid-template-columns: minmax(0, 0.88fr) minmax(460px, 0.74fr);
+  align-items: center;
+  gap: clamp(44px, 8vw, 130px);
+  padding: clamp(58px, 9vh, 112px) clamp(0px, 1.8vw, 26px) clamp(82px, 11vh, 136px);
+  overflow: clip;
   isolation: isolate;
 }
 
-.profile-card::before {
+.hero::before {
+  --backdrop-cut: clamp(34px, 3.8vw, 52px);
   position: absolute;
-  top: 0;
-  right: clamp(28px, 5vw, 64px);
-  left: clamp(28px, 5vw, 64px);
-  height: 7px;
+  top: clamp(42px, 7vh, 80px);
+  right: clamp(-24px, -1.5vw, -8px);
+  bottom: clamp(58px, 8vh, 94px);
+  width: min(38vw, 530px);
   content: "";
-  background: linear-gradient(90deg, var(--moss), var(--cyan), var(--rust));
+  background: linear-gradient(
+    135deg,
+    transparent 0 var(--backdrop-cut),
+    var(--lacquer) var(--backdrop-cut) calc(100% - var(--backdrop-cut)),
+    transparent calc(100% - var(--backdrop-cut)) 100%
+  );
+  animation: backdrop-enter 780ms var(--ease-out) both;
 }
 
-.identity {
-  z-index: 1;
-  grid-area: identity;
-  width: 100%;
-  min-width: 0;
-  align-self: center;
+.hero-light-field {
+  position: absolute;
+  inset: 4% -8% 6% 22%;
+  z-index: -1;
+  pointer-events: none;
+  background: radial-gradient(
+    circle at var(--pointer-x) var(--pointer-y),
+    oklch(72% 0.2 22 / 24%) 0,
+    oklch(72% 0.16 28 / 10%) 18%,
+    transparent 46%
+  );
+  filter: blur(9px);
+  opacity: 0;
+  animation: light-field-enter 900ms 360ms var(--ease-out) forwards;
 }
 
-.handle {
-  width: fit-content;
-  margin: 0 0 clamp(14px, 2.3vw, 22px);
-  color: var(--moss);
-  font-size: clamp(1rem, 1.6vw, 1.16rem);
-  font-weight: 760;
-  line-height: 1;
+.hero-copy {
+  position: relative;
+  z-index: 2;
+  max-width: 700px;
+}
+
+.hero-role {
+  max-width: 31ch;
+  margin: 0 0 26px;
+  color: var(--lacquer);
+  font-size: clamp(0.92rem, 1.1vw, 1.04rem);
+  font-weight: 780;
+  animation: role-enter 560ms 80ms var(--ease-out) both;
 }
 
 h1 {
+  max-width: 11.5ch;
+  margin: 0;
+  font-size: clamp(4rem, 7.1vw, 5.9rem);
+  font-weight: 850;
+  line-height: 0.92;
+  letter-spacing: -0.038em;
+}
+
+.headline-mask {
+  min-width: 0;
   max-width: 100%;
-  margin: 0;
-  color: var(--ink);
-  font-size: clamp(4rem, 11vw, 7.5rem);
-  font-weight: 820;
-  line-height: 0.84;
-  letter-spacing: 0;
+  display: block;
+  overflow: clip;
 }
 
-.intro {
-  width: 100%;
-  max-width: 40ch;
-  margin: clamp(28px, 4.5vw, 48px) 0 0;
+.headline-line {
+  min-width: 0;
+  max-width: 100%;
+  display: block;
+  transform-origin: left bottom;
+  animation: headline-enter 760ms var(--ease-out) both;
+}
+
+.headline-word {
+  display: inline;
+}
+
+.headline-word + .headline-word::before {
+  content: " ";
+}
+
+.headline-mask:nth-child(1) .headline-line {
+  animation-delay: 130ms;
+}
+
+.headline-mask:nth-child(2) .headline-line {
+  animation-delay: 200ms;
+}
+
+.headline-mask:nth-child(3) .headline-line {
+  animation-delay: 270ms;
+}
+
+.hero-description {
+  max-width: 54ch;
+  margin: clamp(26px, 3.5vw, 40px) 0 0;
   color: var(--ink-soft);
-  font-size: clamp(1.16rem, 2vw, 1.48rem);
-  line-height: 1.48;
-  overflow-wrap: break-word;
+  font-size: clamp(1.05rem, 1.4vw, 1.23rem);
+  line-height: 1.58;
+  animation: supporting-copy-enter 650ms 440ms var(--ease-out) both;
 }
 
-.profile-visual {
-  position: relative;
-  z-index: 1;
-  grid-area: signal;
-  min-width: 0;
-  min-height: 330px;
-  align-self: stretch;
-  overflow: hidden;
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: clamp(32px, 4.5vw, 48px);
+  animation: supporting-copy-enter 650ms 510ms var(--ease-out) both;
 }
 
-.signal-field {
-  position: absolute;
-  inset: 0;
-  min-width: 0;
-  height: 100%;
-  overflow: hidden;
-}
-
-.signal-field::before {
-  position: absolute;
-  inset: 2% 0 8% 14%;
-  content: "";
-  background-image:
-    linear-gradient(oklch(43% 0.05 160 / 13%) 1px, transparent 1px),
-    linear-gradient(90deg, oklch(43% 0.05 160 / 13%) 1px, transparent 1px);
-  background-size: 22px 22px;
-  clip-path: polygon(5% 13%, 86% 0, 100% 60%, 35% 100%, 0 68%);
-  opacity: 0.72;
-  animation: dot-breathe 7.5s cubic-bezier(0.16, 1, 0.3, 1) infinite;
-}
-
-.signal-field::after {
-  position: absolute;
-  top: 34%;
-  right: 6%;
-  left: 13%;
-  height: 1px;
-  content: "";
-  background: linear-gradient(90deg, transparent, var(--moss), var(--cyan), transparent);
-  transform: rotate(-18deg);
-  transform-origin: center;
-  animation: route-shift 8s cubic-bezier(0.16, 1, 0.3, 1) infinite alternate;
-}
-
-.plane,
-.node {
-  position: absolute;
-  display: block;
-}
-
-.plane {
-  border: 1px solid oklch(35% 0.045 174 / 25%);
-  box-shadow: 0 20px 48px oklch(28% 0.05 160 / 12%);
-}
-
-.plane-a {
-  top: 12%;
-  right: 1%;
-  width: 58%;
-  height: 44%;
-  background: linear-gradient(135deg, oklch(90% 0.043 196 / 58%), oklch(78% 0.065 206 / 30%));
-  clip-path: polygon(8% 0, 100% 14%, 78% 100%, 0 78%);
-  animation: plane-drift 13s cubic-bezier(0.16, 1, 0.3, 1) infinite alternate;
-}
-
-.plane-b {
-  right: 18%;
-  bottom: 3%;
-  width: 50%;
-  height: 42%;
-  background: linear-gradient(145deg, oklch(82% 0.058 146 / 45%), oklch(96% 0.012 118 / 28%));
-  clip-path: polygon(19% 3%, 100% 0, 84% 78%, 0 100%);
-  animation: plane-drift 15s cubic-bezier(0.16, 1, 0.3, 1) infinite alternate-reverse;
-}
-
-.plane-c {
-  top: 29%;
-  left: 2%;
-  width: 37%;
-  height: 52%;
-  background: linear-gradient(154deg, oklch(57% 0.12 27 / 22%), oklch(91% 0.02 80 / 20%));
-  clip-path: polygon(0 12%, 82% 0, 100% 74%, 14% 100%);
-  animation: plane-drift 17s cubic-bezier(0.16, 1, 0.3, 1) infinite alternate;
-}
-
-.node {
-  width: 11px;
-  height: 11px;
-  border: 2px solid var(--cyan);
-  border-radius: 999px;
-  background: oklch(98% 0.01 118);
-  box-shadow: 0 0 0 6px oklch(58% 0.112 214 / 13%);
-  animation: lamp-breathe 6.8s cubic-bezier(0.16, 1, 0.3, 1) infinite;
-}
-
-.node-a {
-  top: 25%;
-  right: 17%;
-}
-
-.node-b {
-  right: 43%;
-  bottom: 23%;
-  border-color: var(--moss);
-  box-shadow: 0 0 0 6px oklch(41% 0.082 145 / 13%);
-  animation-delay: -2.1s;
-}
-
-.node-c {
-  bottom: 37%;
-  left: 13%;
-  border-color: var(--rust);
-  box-shadow: 0 0 0 6px oklch(50% 0.147 26 / 12%);
-  animation-delay: -4.4s;
-}
-
-.avatar-frame {
-  position: absolute;
-  right: clamp(4px, 2vw, 24px);
-  bottom: clamp(18px, 5vw, 46px);
-  z-index: 2;
-  width: clamp(154px, 18vw, 224px);
-  margin: 0;
-  transform: rotate(1.5deg);
-}
-
-.avatar-frame::before,
-.avatar-frame::after {
-  position: absolute;
-  content: "";
-  border-radius: 8px;
-}
-
-.avatar-frame::before {
-  inset: 12px -12px -12px 12px;
-  z-index: -2;
-  background: oklch(50% 0.147 26 / 76%);
-}
-
-.avatar-frame::after {
-  inset: -10px 10px 10px -10px;
-  z-index: -1;
-  border: 1px solid var(--cyan);
-  background: oklch(92% 0.035 198 / 22%);
-}
-
-.avatar-frame img {
-  display: block;
-  width: 100%;
-  height: auto;
-  aspect-ratio: 1;
-  object-fit: cover;
-  border: 1px solid var(--ink);
-  border-radius: 8px;
-  filter: saturate(0.95) contrast(1.04);
-}
-
-.social-links {
-  z-index: 1;
-  grid-area: links;
-  min-width: 0;
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 1px;
-  overflow: hidden;
-  background: var(--line);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-}
-
-.social-links a {
-  position: relative;
-  min-width: 0;
-  min-height: 112px;
-  display: grid;
-  align-content: center;
-  gap: 8px;
-  padding: clamp(16px, 2.3vw, 24px);
-  background: oklch(97.5% 0.01 118 / 88%);
+.action {
+  min-height: 52px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  padding: 14px 20px;
+  font-size: 0.9rem;
+  font-weight: 790;
   text-decoration: none;
   transition:
-    background-color 180ms cubic-bezier(0.19, 1, 0.22, 1),
-    color 180ms cubic-bezier(0.19, 1, 0.22, 1),
-    transform 180ms cubic-bezier(0.19, 1, 0.22, 1);
+    color 200ms var(--ease-out),
+    background-color 200ms var(--ease-out),
+    transform 200ms var(--ease-out);
 }
 
-.social-links a::after {
-  position: absolute;
-  top: 22px;
-  right: 22px;
-  width: 8px;
-  height: 8px;
-  content: "";
-  border-top: 2px solid currentColor;
-  border-right: 2px solid currentColor;
-  opacity: 0.32;
-  transform: rotate(45deg);
-}
-
-.social-links a:hover,
-.social-links a:focus-visible {
-  color: oklch(97% 0.012 118);
+.action-primary {
+  color: var(--paper);
   background: var(--ink);
-  outline: none;
-  transform: translateY(-2px);
 }
 
-.social-links span {
-  font-size: clamp(0.98rem, 1.6vw, 1.16rem);
-  font-weight: 780;
-  line-height: 1.1;
+.action-secondary {
+  box-shadow: inset 0 0 0 1px var(--ink);
 }
 
-.social-links small {
-  min-width: 0;
-  overflow-wrap: anywhere;
-  color: currentColor;
-  font-size: 0.84rem;
-  line-height: 1.28;
-  opacity: 0.72;
+.action:hover,
+.action:focus-visible {
+  transform: translateY(-3px) scale(1.018);
 }
 
-.profile-footer {
+.action:active {
+  transform: translateY(0) scale(0.975);
+}
+
+.action-primary:hover,
+.action-primary:focus-visible {
+  background: var(--lacquer);
+}
+
+.action-secondary:hover,
+.action-secondary:focus-visible {
+  color: var(--paper);
+  background: var(--ink);
+}
+
+.wordmark:focus-visible,
+.header-nav a:focus-visible,
+.action:focus-visible,
+.contact-section a:focus-visible,
+.site-footer a:focus-visible {
+  outline: 3px solid var(--gold);
+  outline-offset: 4px;
+}
+
+.portrait-stage-shell {
+  --portrait-cut: clamp(30px, 3.7vw, 46px);
+  --portrait-gradient-cut: clamp(21.21px, 2.62vw, 32.53px);
+  position: relative;
   z-index: 1;
-  grid-area: footer;
-  min-width: 0;
+  width: min(100%, 590px);
+  justify-self: end;
+  animation: portrait-enter 820ms 170ms var(--ease-out) both;
+}
+
+.portrait-stage-shell::before {
+  position: absolute;
+  top: -18px;
+  right: -18px;
+  width: 96px;
+  height: 96px;
+  border-top: 2px solid var(--gold);
+  border-right: 2px solid var(--gold);
+  content: "";
+}
+
+.portrait-stage {
+  width: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: var(--ink);
+  clip-path: polygon(
+    var(--portrait-cut) 0,
+    100% 0,
+    100% calc(100% - var(--portrait-cut)),
+    calc(100% - var(--portrait-cut)) 100%,
+    0 100%,
+    0 var(--portrait-cut)
+  );
+}
+
+.portrait-media {
+  position: relative;
+  aspect-ratio: 0.86;
+  overflow: hidden;
+  background: var(--lacquer-dark);
+  isolation: isolate;
+}
+
+.portrait-media img,
+.portrait-canvas,
+.portrait-glare {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.portrait-media img {
+  z-index: 1;
+  object-fit: cover;
+  object-position: 50% 42%;
+  filter: saturate(1.08) contrast(1.02);
+  transform: scale(1.035);
+  transition:
+    opacity 320ms var(--ease-out),
+    transform 900ms var(--ease-out);
+}
+
+.portrait-stage:hover .portrait-media img {
+  transform: scale(1.07);
+}
+
+.portrait-canvas {
+  z-index: 2;
+  display: block;
+  background: var(--lacquer-dark);
+  opacity: 0;
+  touch-action: pan-y;
+  transition: opacity 180ms var(--ease-out);
+}
+
+.portrait-stage[data-portrait-state="ready"] .portrait-media img {
+  opacity: 0;
+}
+
+.portrait-stage[data-portrait-state="ready"] .portrait-canvas {
+  opacity: 1;
+}
+
+.portrait-glare {
+  z-index: 3;
+  pointer-events: none;
+  background:
+    linear-gradient(112deg, oklch(100% 0 0 / 28%), transparent 18% 70%, oklch(55% 0.22 25 / 12%)),
+    radial-gradient(circle at 67% 18%, oklch(100% 0 0 / 20%), transparent 25%),
+    radial-gradient(ellipse at center, transparent 54%, oklch(10% 0.025 285 / 28%) 100%);
+  transform: translate3d(var(--parallax-x), var(--parallax-y), 0) scale(1.06);
+  transition: transform 260ms var(--ease-out);
+}
+
+.portrait-stage figcaption {
+  min-height: 68px;
   display: flex;
-  justify-content: flex-end;
-  color: var(--ink-soft);
-  font-size: 0.78rem;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 16px calc(var(--portrait-cut) + 18px) 18px 20px;
+  color: var(--paper);
+  background: var(--ink);
+}
+
+.portrait-stage figcaption strong {
+  font-size: 1.18rem;
+  font-weight: 850;
+}
+
+.portrait-stage figcaption span {
+  color: var(--blush);
+  font-size: 0.76rem;
   font-weight: 680;
 }
 
-.profile-footer p {
+.hero-margin-note {
+  position: absolute;
+  bottom: 34px;
+  left: 0;
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.72rem;
+  font-weight: 690;
+  animation: supporting-copy-enter 650ms 620ms var(--ease-out) both;
+}
+
+.focus-section {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 0.85fr) minmax(420px, 1.15fr);
+  gap: clamp(54px, 10vw, 170px);
+  padding: clamp(92px, 12vw, 180px) max(24px, calc((100vw - 1440px) / 2 + 24px));
+  color: var(--paper);
+  background: var(--ink);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.focus-section::before {
+  position: absolute;
+  top: 50%;
+  left: -0.06em;
+  z-index: -1;
+  color: transparent;
+  font-size: clamp(11rem, 31vw, 31rem);
+  font-weight: 900;
+  line-height: 0.7;
+  letter-spacing: -0.08em;
+  content: "CLEAR";
+  opacity: 0.12;
+  transform: translate3d(-7%, -50%, 0);
+  -webkit-text-stroke: 1px oklch(97% 0.006 285 / 70%);
+  text-stroke: 1px oklch(97% 0.006 285 / 70%);
+}
+
+.focus-statement p {
+  margin: 0 0 28px;
+  color: var(--blush);
+  font-size: 0.94rem;
+  font-weight: 780;
+}
+
+.focus-statement h2 {
+  max-width: 12ch;
+  margin: 0;
+  font-size: clamp(3.2rem, 6vw, 5.5rem);
+  font-weight: 820;
+  line-height: 0.98;
+  letter-spacing: -0.036em;
+}
+
+.focus-list {
+  margin: 0;
+  align-self: end;
+}
+
+.focus-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(112px, 0.54fr) minmax(0, 1.46fr) auto;
+  align-items: baseline;
+  gap: 24px;
+  padding: 28px 0;
+  border-top: 1px solid oklch(97% 0.006 285 / 24%);
+  isolation: isolate;
+}
+
+.focus-item::before {
+  position: absolute;
+  inset: 1px -18px 0;
+  z-index: -1;
+  pointer-events: none;
+  content: "";
+  background: linear-gradient(90deg, oklch(97% 0.006 285 / 9%), transparent 78%);
+  opacity: 0;
+  transform: scaleX(0.86);
+  transform-origin: left center;
+  transition:
+    opacity 220ms var(--ease-out),
+    transform 340ms var(--ease-out);
+}
+
+.focus-item:last-child {
+  border-bottom: 1px solid oklch(97% 0.006 285 / 24%);
+}
+
+.focus-item dt {
+  color: var(--blush);
+  font-size: 1.08rem;
+  font-weight: 790;
+  transition: color 220ms var(--ease-out);
+}
+
+.focus-item dd {
+  max-width: 42ch;
+  margin: 0;
+  color: oklch(88% 0.012 285);
+  line-height: 1.55;
+  transition: color 220ms var(--ease-out);
+}
+
+.focus-item span {
+  color: oklch(74% 0.025 285);
+  font-size: 0.72rem;
+  font-weight: 680;
+  transition: color 240ms var(--ease-out);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .focus-item:hover::before {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+
+  .focus-item:hover dt {
+    color: var(--gold);
+  }
+
+  .focus-item:hover dd {
+    color: var(--paper);
+  }
+
+  .focus-item:hover span {
+    color: var(--blush);
+  }
+}
+
+.contact-section {
+  position: relative;
+  padding: clamp(94px, 13vw, 190px) max(24px, calc((100vw - 1440px) / 2 + 24px));
+  color: var(--paper);
+  background: var(--lacquer);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.contact-section::before {
+  position: absolute;
+  inset: -25%;
+  z-index: -1;
+  pointer-events: none;
+  content: "";
+  background: radial-gradient(circle at 68% 42%, oklch(91% 0.12 50 / 23%), transparent 28%);
+  animation: contact-light-drift 7s ease-in-out infinite alternate;
+}
+
+.contact-section::after {
+  position: absolute;
+  top: 50%;
+  right: clamp(10px, 5vw, 84px);
+  z-index: -1;
+  color: oklch(98% 0.01 25 / 16%);
+  font-size: clamp(13rem, 31vw, 31rem);
+  font-weight: 650;
+  line-height: 0.7;
+  content: "↗";
+  transform: translateY(-50%) rotate(-5deg);
+  transition: transform 500ms var(--ease-out);
+}
+
+.contact-section:hover::after {
+  transform: translateY(-53%) rotate(0deg) scale(1.04);
+}
+
+.contact-section > p {
+  margin: 0 0 24px;
+  font-size: 1rem;
+  font-weight: 760;
+}
+
+.contact-section h2 {
+  max-width: 11ch;
+  margin: 0;
+  font-size: clamp(3.4rem, 8vw, 6rem);
+  font-weight: 850;
+  line-height: 0.91;
+  letter-spacing: -0.04em;
+}
+
+.contact-section a {
+  width: fit-content;
+  display: inline-flex;
+  align-items: center;
+  gap: 20px;
+  margin-top: clamp(42px, 6vw, 72px);
+  padding-bottom: 7px;
+  border-bottom: 2px solid currentColor;
+  font-size: clamp(1.02rem, 1.4vw, 1.2rem);
+  font-weight: 800;
+  text-decoration: none;
+  transition: gap 240ms var(--ease-out);
+}
+
+.contact-section a:hover,
+.contact-section a:focus-visible {
+  gap: 30px;
+}
+
+.site-footer {
+  min-height: 106px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 28px;
+}
+
+.footer-identity {
+  font-weight: 820;
+  text-decoration: none;
+}
+
+.footer-identity span {
+  color: var(--lacquer);
+  font-size: 0.76rem;
+}
+
+.site-footer nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 24px;
+}
+
+.site-footer nav a,
+.site-footer p {
+  color: var(--ink-soft);
+  font-size: 0.76rem;
+  font-weight: 680;
+}
+
+.site-footer nav a {
+  text-decoration: none;
+}
+
+.site-footer nav a:hover,
+.site-footer nav a:focus-visible {
+  color: var(--lacquer);
+}
+
+.site-footer p {
+  justify-self: end;
   margin: 0;
 }
 
-@keyframes field-drift {
+@keyframes status-pulse {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: scale(0.82);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes backdrop-enter {
+  from {
+    opacity: 0;
+    transform: translateX(28px);
+  }
+}
+
+@keyframes light-field-enter {
   to {
-    background-position: 56px 28px;
+    opacity: 1;
   }
 }
 
-@keyframes dot-breathe {
-  0%,
-  100% {
-    opacity: 0.38;
-    transform: translate3d(0, 0, 0) scale(0.98);
-  }
-
-  50% {
-    opacity: 0.82;
-    transform: translate3d(0, -6px, 0) scale(1.02);
+@keyframes role-enter {
+  from {
+    opacity: 0;
+    transform: translateX(-18px);
   }
 }
 
-@keyframes lamp-breathe {
-  0%,
-  100% {
-    opacity: 0.28;
-    transform: translate3d(0, 0, 0) scale(0.88);
-  }
-
-  50% {
-    opacity: 0.78;
-    transform: translate3d(0, -4px, 0) scale(1.08);
+@keyframes headline-enter {
+  from {
+    filter: blur(8px);
+    opacity: 0;
+    transform: translateY(108%) rotate(1.4deg);
   }
 }
 
-@keyframes plane-drift {
-  0% {
-    transform: translate3d(-4px, 5px, 0) rotate(-1deg);
-  }
-
-  100% {
-    transform: translate3d(7px, -6px, 0) rotate(1.2deg);
+@keyframes supporting-copy-enter {
+  from {
+    filter: blur(5px);
+    opacity: 0;
+    transform: translateY(16px);
   }
 }
 
-@keyframes quiet-float {
-  0% {
-    opacity: 0.42;
-    transform: translate3d(-2%, 1%, 0) rotate(-2deg);
-  }
-
-  100% {
-    opacity: 0.74;
-    transform: translate3d(1%, -2%, 0) rotate(1deg);
+@keyframes portrait-enter {
+  from {
+    filter: saturate(0.5) blur(7px);
+    opacity: 0;
+    transform: translateY(24px) scale(0.97);
   }
 }
 
-@keyframes route-shift {
-  0% {
-    opacity: 0.38;
-    transform: translate3d(-8px, 5px, 0) rotate(-18deg);
+@keyframes contact-light-drift {
+  from {
+    opacity: 0.45;
+    transform: translate3d(-4%, 1%, 0) scale(0.94);
   }
-
-  100% {
-    opacity: 0.72;
-    transform: translate3d(8px, -4px, 0) rotate(-18deg);
-  }
-}
-
-@media (max-width: 900px) {
-  .profile-card {
-    grid-template-areas:
-      "identity"
-      "signal"
-      "links"
-      "footer";
-    grid-template-columns: 1fr;
-  }
-
-  .signal-field {
-    min-height: 210px;
-  }
-
-  .profile-visual {
-    min-height: 240px;
-  }
-
-  .social-links {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  to {
+    opacity: 1;
+    transform: translate3d(4%, -2%, 0) scale(1.06);
   }
 }
 
-@media (max-width: 620px) {
-  body {
-    background:
-      linear-gradient(162deg, oklch(79% 0.07 149 / 28%) 0 34%, transparent 34% 100%),
-      linear-gradient(145deg, var(--paper-warm), var(--paper), var(--paper-cool));
+@keyframes clear-drift {
+  from {
+    transform: translate3d(-14%, -50%, 0);
   }
-
-  .page-shell {
-    display: block;
-    width: 100%;
-    max-width: 100%;
-    padding: 12px;
+  to {
+    transform: translate3d(7%, -50%, 0);
   }
+}
 
-  .profile-card {
-    width: 100%;
-    max-width: 100%;
-    min-height: calc(100svh - 24px);
-    margin: 0 auto;
-    gap: 28px;
-    padding: clamp(24px, 7vw, 34px);
+@supports (animation-timeline: view()) {
+  .focus-section::before {
+    animation: clear-drift linear both;
+    animation-timeline: view();
+    animation-range: entry -10% exit 110%;
   }
+}
 
-  .profile-card::before {
-    right: clamp(24px, 7vw, 34px);
-    left: clamp(24px, 7vw, 34px);
-    height: 6px;
+@media (max-width: 1080px) {
+  .hero {
+    grid-template-columns: minmax(0, 0.9fr) minmax(380px, 0.7fr);
+    gap: 44px;
   }
 
   h1 {
-    font-size: clamp(3.4rem, 19vw, 5rem);
+    font-size: clamp(3.7rem, 7.6vw, 5.2rem);
   }
 
-  .intro {
-    max-width: 31ch;
-    font-size: 1rem;
-  }
-
-  .signal-field {
-    min-height: 168px;
-  }
-
-  .profile-visual {
-    display: grid;
-    min-height: 210px;
-  }
-
-  .avatar-frame {
-    position: relative;
-    top: auto;
-    right: auto;
-    bottom: auto;
-    width: min(39vw, 146px);
-    aspect-ratio: 1;
-    margin: 18px auto 0;
-    place-self: start center;
-  }
-
-  .social-links {
+  .focus-section {
     grid-template-columns: 1fr;
   }
 
-  .social-links a {
-    min-height: 84px;
-    padding: 16px 18px;
+  .focus-statement h2 {
+    max-width: 15ch;
+  }
+}
+
+@media (max-width: 820px) {
+  .site-header,
+  .hero,
+  .site-footer {
+    width: min(100% - 32px, 1440px);
   }
 
-  .profile-footer {
-    justify-content: flex-start;
+  .site-header {
+    grid-template-columns: 1fr auto;
+  }
+
+  .header-nav {
+    display: none;
+  }
+
+  .hero {
+    min-height: auto;
+    grid-template-columns: 1fr;
+    gap: 30px;
+    padding: 64px 0 92px;
+  }
+
+  .hero::before {
+    display: none;
+  }
+
+  .hero-light-field {
+    inset: 12% -20% 20% -10%;
+  }
+
+  .hero-copy {
+    display: contents;
+  }
+
+  .hero-role {
+    grid-row: 1;
+  }
+
+  .hero h1 {
+    grid-row: 2;
+    max-width: 10.5ch;
+  }
+
+  .hero-description {
+    grid-row: 4;
+    margin-top: 10px;
+  }
+
+  .hero-actions {
+    grid-row: 5;
+    margin-top: 6px;
+  }
+
+  .portrait-stage-shell {
+    grid-row: 3;
+    width: min(88%, 540px);
+    justify-self: start;
+    margin-left: 4%;
+    margin-bottom: 18px;
+    isolation: isolate;
+  }
+
+  .portrait-stage-shell::after {
+    position: absolute;
+    inset: 18px -18px -18px 18px;
+    z-index: -1;
+    content: "";
+    background: linear-gradient(
+      135deg,
+      transparent 0 var(--portrait-gradient-cut),
+      var(--lacquer) var(--portrait-gradient-cut) calc(100% - var(--portrait-gradient-cut)),
+      transparent calc(100% - var(--portrait-gradient-cut)) 100%
+    );
+  }
+
+  .portrait-media {
+    aspect-ratio: 1.08;
+  }
+
+  .portrait-media img {
+    object-position: 50% 34%;
+  }
+
+  .hero-margin-note {
+    display: none;
+  }
+
+  .focus-section {
+    grid-template-columns: 1fr;
+    padding-inline: 24px;
+  }
+
+  .focus-section::before {
+    top: 42%;
+    font-size: clamp(9rem, 43vw, 18rem);
+  }
+
+  .focus-item {
+    grid-template-columns: minmax(100px, 0.5fr) minmax(0, 1.5fr);
+  }
+
+  .focus-item span {
+    display: none;
+  }
+
+  .site-footer {
+    grid-template-columns: 1fr auto;
+  }
+
+  .site-footer nav {
+    display: none;
+  }
+}
+
+@media (max-width: 560px) {
+  .site-header {
+    min-height: 74px;
+  }
+
+  .wordmark small {
+    display: none;
+  }
+
+  .availability {
+    max-width: 21ch;
+    text-align: right;
+  }
+
+  .hero {
+    padding-top: 48px;
+  }
+
+  .hero-role {
+    margin-bottom: 20px;
+  }
+
+  h1 {
+    max-width: 9.5ch;
+    font-size: clamp(3.35rem, 16vw, 4.5rem);
+  }
+
+  .hero-description {
+    font-size: 1rem;
+  }
+
+  .hero-actions,
+  .action {
+    width: 100%;
+  }
+
+  .portrait-stage-shell {
+    width: calc(100% - 20px);
+    margin-left: 0;
+  }
+
+  .portrait-stage-shell::before {
+    top: -12px;
+    right: -12px;
+    width: 68px;
+    height: 68px;
+  }
+
+  .portrait-stage figcaption {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .focus-statement h2 {
+    font-size: clamp(3rem, 14vw, 4.4rem);
+  }
+
+  .focus-item {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    padding: 22px 0;
+  }
+
+  .focus-item dd {
+    font-size: 0.96rem;
+  }
+
+  .contact-section h2 {
+    font-size: clamp(3rem, 16vw, 4.6rem);
+  }
+
+  .contact-section::after {
+    right: -0.08em;
+    font-size: 15rem;
+  }
+}
+
+@media (max-width: 430px) {
+  .site-header {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .availability {
+    min-width: 0;
+    max-width: none;
+    white-space: nowrap;
+  }
+
+  .availability-dot {
+    order: 2;
+  }
+
+  .availability-long {
+    display: none;
+  }
+
+  .availability-short {
+    display: inline;
+    order: 1;
+  }
+
+  .hero h1,
+  .headline-mask,
+  .headline-line {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .headline-word {
+    display: block;
+  }
+
+  .headline-word + .headline-word::before {
+    content: none;
+  }
+
+  .portrait-stage-shell {
+    width: calc(100% - 18px);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
   *,
   *::before,
   *::after {
-    scroll-behavior: auto !important;
     animation-duration: 0.001ms !important;
     animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
     transition-duration: 0.001ms !important;
+  }
+
+  .hero-light-field {
+    opacity: 1;
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -533,7 +533,7 @@ h1 {
   transition: color 220ms var(--ease-out);
 }
 
-.focus-item span {
+.focus-item .focus-signal {
   color: oklch(74% 0.025 285);
   font-size: 0.72rem;
   font-weight: 680;
@@ -554,7 +554,7 @@ h1 {
     color: var(--paper);
   }
 
-  .focus-item:hover span {
+  .focus-item:hover .focus-signal {
     color: var(--blush);
   }
 }
@@ -880,16 +880,22 @@ h1 {
     grid-template-columns: minmax(100px, 0.5fr) minmax(0, 1.5fr);
   }
 
-  .focus-item span {
+  .focus-item .focus-signal {
     display: none;
   }
 
   .site-footer {
     grid-template-columns: 1fr auto;
+    align-content: center;
+    row-gap: 14px;
+    padding-block: 22px;
   }
 
   .site-footer nav {
-    display: none;
+    grid-column: 1 / -1;
+    grid-row: 2;
+    justify-content: flex-start;
+    gap: 12px 22px;
   }
 }
 


### PR DESCRIPTION
## Summary

- redesign the personal profile site around a bold editorial layout and updated developer positioning
- add a WebGL2 CRT portrait with phosphor mask, curvature, bloom, halation, noise, and pointer/touch interference
- add responsive desktop and mobile compositions with accessible reduced-motion and image fallbacks
- update primary social links to GitHub and X, and add Blog and Medium destinations
- use one true transparent clip for the portrait and caption so dynamic background lighting remains visible through both symmetric corners

## Impact

The homepage now presents a clearer personal brand and a more distinctive interactive hero while preserving semantic HTML and crawlable profile content. Browsers without a working WebGL2 context fall back to the original avatar.

## Verification

- `pnpm format`
- `pnpm lint`
- `pnpm build`
- `git diff --check`
- visual comparison in Chrome and the Codex in-app browser at 375x667 and 1200x720
- pointer-driven glow and transparent corner verification in both browsers
